### PR TITLE
Fix real-cpu-usage-chart - pass integers to spark

### DIFF
--- a/System/real-cpu-usage-chart.10s.sh
+++ b/System/real-cpu-usage-chart.10s.sh
@@ -20,7 +20,7 @@ fi
 IDLE=`top -F -R -l3 | grep "CPU usage" | tail -1 | \
       egrep -o '[0-9]{0,3}\.[0-9]{0,2}% idle' | sed 's/% idle//'`
 
-CURRENT=`echo 100 - $IDLE | bc`
+CURRENT=$(printf "%.0f" $(echo 100 - $IDLE | bc))
 
 # Let's put/keep last 6 values (= one minute) in HISTORY_FILE
 HISTORY_FILE="${HOME}/.cpu.history"


### PR DESCRIPTION
as it doesn't like small decimals (e.g. ".2" when $IDLE is "99.8").