### PR TITLE
Restore name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Special thanks to everyone who has contributed:
 - Dylan Evans - [https://github.com/whonut](https://github.com/whonut))
 - Daniel Seripap - [https://github.com/seripap](https://github.com/seripap)
 - Alexandre Espinosa Menor - [https://github.com/alexandregz](https://github.com/alexandregz)
+- Damien Lajarretie - [@dqms_output](https://twitter.com/dqms_output)
 - Dan Turkel - [https://danturkel.com/](https://danturkel.com/)
 - Marian Schubert - [https://github.com/maio](https://github.com/maio)
 - Stratos Xakoustos - [https://github.com/Stratouklos](https://github.com/Stratouklos)


### PR DESCRIPTION
My name was apparently removed accidentally by another contributor ;) https://github.com/matryer/bitbar/commit/c15301be16a89e14df0ddac0d737307e44416457