### PR TITLE
Dev/Github/notifications: initial implementation

### DIFF
--- a/Dev/GitHub/notifications.30s.py
+++ b/Dev/GitHub/notifications.30s.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Github Notifications by Keith Cirkel
+# Fetch Github notifications in your menu bar!
+
+import json
+import urllib2
+import os
+import re
+
+api_key = os.getenv('GITHUB_TOKEN', 'Please put your GitHub Token here')
+url = 'https://api.github.com/notifications'
+
+request = urllib2.Request( url, headers     = { 'Authorization': 'token ' + api_key } )
+response = urllib2.urlopen( request )
+notifications = json.load( response )
+
+color = '#7d7d7d'
+if len( notifications ) > 0:
+    color='#4078C0'
+
+print ( u'\u25CF | color=' + color ).encode( 'utf-8' )
+print '---'
+for notification in notifications:
+    title = notification['subject']['title']
+    repo = notification['repository']['full_name']
+    url = re.sub( '^https://api.github.com/repos/', 'https://github.com/', notification['subject']['url'] )
+    url = re.sub( '/pulls/', '/pull/', url )
+    print ( '%s: %s | refresh=true href=%s' % ( repo, title, url ) ).encode( 'utf-8' )

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repo contains scripts, programs and command-line tools that add functionali
 - TravisCI check
 - Docker status (docker-machine and running containers status)
 - Xcode version
+- Github Notifications
 
 ####Finance
 - Stock tracker


### PR DESCRIPTION
This bitbar plugin fetches your GitHub notifications through the notifications API, and lists them as menu bar entries. If you have notificarions you get a blue dot, otherwise you get a dim grey dot. Each menu item is clickable - and takes you to the issue or pull request that the notification was for.

See screenshots:

No notifications!
<img width="216" alt="screen shot 2016-01-07 at 22 59 40" src="https://cloud.githubusercontent.com/assets/118266/12185381/8d8c0aca-b592-11e5-8398-f5abecad92ae.PNG">

Many notifications!
<img width="677" alt="screen shot 2016-01-07 at 23 00 15" src="https://cloud.githubusercontent.com/assets/118266/12185392/9b528f4e-b592-11e5-9904-24b00d7c6c2a.PNG">

If you want to test what notifications look like, change like 12 (`url =...`) to have the query string `?all=true`.
