### PR TITLE
Support commit notification

### DIFF
--- a/Dev/GitHub/notifications.30s.py
+++ b/Dev/GitHub/notifications.30s.py
@@ -26,4 +26,5 @@ for notification in notifications:
     repo = notification['repository']['full_name']
     url = re.sub( '^https://api.github.com/repos/', 'https://github.com/', notification['subject']['url'] )
     url = re.sub( '/pulls/', '/pull/', url )
+    url = re.sub( '/commits/', '/commit/', url )
     print ( '%s: %s | refresh=true href=%s' % ( repo, title, url ) ).encode( 'utf-8' )


### PR DESCRIPTION
As in `pulls`, `commits` has to be substituted for `commit` to go directly to the notification

See the difference between these urls

```
https://github.com/driftyco/ionicons/commit/57a7bf240f7dd42ce8c1b09b2f6bf3708d4a0c2a
https://github.com/driftyco/ionicons/commits/57a7bf240f7dd42ce8c1b09b2f6bf3708d4a0c2a
```

cc @keithamus