### PR TITLE
Add Finance/rbc plugin

### DIFF
--- a/Finance/rbc.10m.sh
+++ b/Finance/rbc.10m.sh
@@ -10,7 +10,8 @@
 # They should be added in PATH
 
 export PATH=/usr/local/bin:~/Applications/go/bin:$PATH
-json=$(curl -s -L http://rbc.ru | pup '.indicators__group json{}') out="`echo $json | jq -r '.[] | .children | .[1:] | .[] as $c | "\($c.children | map(.text) | join(" ")) | color=\(if $c.children | .[0] | .text == "▲" then "green" else "red" end) | href=\($c.href)"'`"
+json=$(curl -s -L http://rbc.ru | pup '.indicators__group json{}')
+out="`echo $json | jq -r '.[] | .children | .[1:] | .[] as $c | "\($c.children | map(.text) | join(" ")) | color=\(if $c.children | .[0] | .text == "▲" then "green" else "red" end) | href=\($c.href)"'`"
 echo "$out" | grep Brent
 echo "---"
 echo "$out" | grep -v Brent | grep -v EUR/USD | grep USD | sed 's/color=green/color=111/;s/color=red/color=green/;s/color=111/color=red/'

--- a/Finance/rbc.10m.sh
+++ b/Finance/rbc.10m.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# File: rbc.15.m.sh
+# Description: Plugin for BitBar (github.com/matryer/bitbar) displaying russian
+#              stock-market indicators from rbc.ru
+# Author: github.com/schmooser
+# Dependencies:
+#   jq - github.com/stedolan/jq
+#   pup - github.com/EricChiang/pup
+#   curl - curl.haxx.se
+# They should be added in PATH
+
+export PATH=/usr/local/bin:~/Applications/go/bin:$PATH
+json=$(curl -s -L http://rbc.ru | pup '.indicators__group json{}') out="`echo $json | jq -r '.[] | .children | .[1:] | .[] as $c | "\($c.children | map(.text) | join(" ")) | color=\(if $c.children | .[0] | .text == "▲" then "green" else "red" end) | href=\($c.href)"'`"
+echo "$out" | grep Brent
+echo "---"
+echo "$out" | grep -v Brent | grep -v EUR/USD | grep USD | sed 's/color=green/color=111/;s/color=red/color=green/;s/color=111/color=red/'
+echo "$out" | grep -v Brent | grep -v EUR/USD | grep EUR | sed 's/color=green/color=111/;s/color=red/color=green/;s/color=111/color=red/'
+echo "$out" | grep EUR/USD
+echo "$out" | grep -v Brent | grep -v USD | grep -v EUR

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repo contains scripts, programs and command-line tools that add functionali
 - Stock tracker
 - Currency tracker
 - hour_logger (money management for freelance work). [Visit hour_logger website](https://github.com/udeyrishi/hour_logger).
+- Russian stock market tracker
 
 ####Lifestyle
 - Sleeping Time Cycles
@@ -116,6 +117,7 @@ Special thanks to everyone who has contributed:
 - Maxime Bertheau - [https://github.com/maxoumime](https://github.com/maxoumime)
 - Joe Canero - [https://github.com/caneroj1](https://github.com/caneroj1)
 - Goran Gajic - [https://github.com/gorangajic](https://github.com/gorangajic)
+- Pavel Popov - [https://github.com/schmooser](https://github.com/schmooser)
 
 ## Add your own plugin
 


### PR DESCRIPTION
This plugin adds tracking of main Russian stock market indicators by parsing [Russian Business Consulting (RBC)](http://rbc.ru) agency website mainpage.

External tools [jq](https://stedolan.github.io/jq/), [pup](https://github.com/EricChiang/pup) and curl are required.

Example of plugin usage:
![screen shot 2016-01-08 at 21 34 26](https://cloud.githubusercontent.com/assets/480160/12206066/ee9db3be-b64f-11e5-96ae-11f7678cb905.png)
