### PR TITLE
Dev/Docker/docker-status: clickable entries

### DIFF
--- a/Dev/Docker/docker-status.1m.sh
+++ b/Dev/Docker/docker-status.1m.sh
@@ -5,9 +5,8 @@
 #
 # Displays the status of docker machines and running containers
 
-
 export PATH="/usr/local/bin:/usr/bin:$PATH"
-echo "⚓️"
+echo "⚓️ | dropdown=false"
 echo "---"
 
 DOCKER_MACHINES="$(docker-machine ls -q)"
@@ -19,19 +18,24 @@ fi
 echo "${DOCKER_MACHINES}" | while read -r machine; do
   STATUS=$(docker-machine status "$machine")
   if [ "$STATUS" = "Running" ]; then
-    echo "$machine | color=green"
+    echo "$machine | color=green bash=$(which docker-machine) param1=stop param2=$machine terminal=false refresh=true"
     ENV=$(docker-machine env --shell sh "$machine")
     eval "$ENV"
-    CONTAINERS="$(docker ps --format "{{.Names}} ({{.Image}})")"
+    CONTAINERS="$(docker ps --format "{{.Names}} ({{.Image}})|{{.ID}}")"
     if [ -z "$CONTAINERS" ]; then
       echo "No running containers"
     else
-      echo "${CONTAINERS}" | while read -r container; do
-        echo "🆙 $container | color=black"
+      LAST_CONTAINER=$(echo "$CONTAINERS" | tail -n1 )
+      echo "${CONTAINERS}" | while read -r CONTAINER; do
+        CONTAINER_ID=$(echo "$CONTAINER" | sed 's/.*|//')
+        CONTAINER_NAME=$(echo "$CONTAINER" | sed 's/|.*//')
+        SYM="├"
+        if [ "$CONTAINER" = "$LAST_CONTAINER" ]; then SYM="└"; fi
+        echo "$SYM $CONTAINER_NAME | color=green bash=$(which docker) param1=stop param2=$CONTAINER_ID terminal=false refresh=true"
       done
     fi
   else
-    echo "$machine (not running)"
+    echo "$machine (not running) | color=red bash=$(which docker-machine) param1=start param2=$machine terminal=false refresh=true"
   fi
   echo "---"
 done


### PR DESCRIPTION
This commit gives each menu entry some clickable interactivity:

Docker machines which are on (and highlighted in green) - when
clicked - will be shut down (and subsequently all of their containers
will be stopped). If they are off (the ones highlighted in red) they
will be booted up.

The containers listed per machine now use tree like UTF-8 symbols to
better show their connection to their respective machine. In addition,
when clicked, they will be shut down. There is no concept of a
"non-running" container within this plugin, nor really with Docker, and
so there isn't an option to start containers up.

In addition to this, a small change has been made to the icon -
`dropdown=false` - to prevent the anchor icon showing up in the menus.