### PR TITLE
Ignore blank lines in todo list

### DIFF
--- a/Lifestyle/todo.30s.sh
+++ b/Lifestyle/todo.30s.sh
@@ -4,7 +4,7 @@
 #
 
 todo_file="$HOME/.todo"
-count=$(sed "/^\s*$/d" "$todo_file" | wc -l | awk '{print $1}')
+count=$(grep -c '[^[:space:]]' "$todo_file" | awk '{print $1}')
 echo "Todos: $count"
 echo "---"
 cat "$todo_file"

--- a/Lifestyle/todo.30s.sh
+++ b/Lifestyle/todo.30s.sh
@@ -4,7 +4,7 @@
 #
 
 todo_file="$HOME/.todo"
-count=$(wc -l "$todo_file" | awk '{print $1}')
+count=$(sed "/^\s*$/d" "$todo_file" | wc -l | awk '{print $1}')
 echo "Todos: $count"
 echo "---"
 cat "$todo_file"


### PR DESCRIPTION
This is useful when there are empty lines at the end of file, etc.
With this fix, these empty lines are not added to the todo count.