### PR TITLE
Spellcheck & Python lint

### DIFF
--- a/Finance/currency-tracker.1m.py
+++ b/Finance/currency-tracker.1m.py
@@ -12,23 +12,23 @@ import json
 
 # Write here the currencies you want to see
 
-#Base comparaison currency
-currFrom="EUR"
-#Array of tracked currencies
-currTo=["CAD", "USD"]
+# Base comparaison currency
+currFrom = "EUR"
+# Array of tracked currencies
+currTo = ["CAD", "USD"]
 
 urlParamTo = currTo[0]
 if len(currTo) > 1:
     urlParamTo = ",".join(currTo)
 
-url="http://api.fixer.io/latest?base=" + currFrom  +"&symbols=" + urlParamTo
+url = "http://api.fixer.io/latest?base=" + currFrom + "&symbols=" + urlParamTo
 
-result=urllib2.urlopen(url).read()
+result = urllib2.urlopen(url).read()
 
-jsonCurr=json.loads(result)
+jsonCurr = json.loads(result)
 
-rates=jsonCurr["rates"]
-keys=rates.keys();
+rates = jsonCurr["rates"]
+keys = rates.keys()
 
 for key in reversed(keys):
 	print key + ": " + str(rates[key])

--- a/System/Battery/battery_cycles.12h.sh
+++ b/System/Battery/battery_cycles.12h.sh
@@ -23,9 +23,9 @@ echo "---"
 # No way to get the Macbook age from script directly
 
 color=green
-if [ $cycles -gt 1000 ]; then
+if [ "$cycles" -gt 1000 ]; then
     color=red
-elif [ $cycles -gt 750 ]; then
+elif [ "$cycles" -gt 750 ]; then
     color=orange
 fi
 
@@ -35,7 +35,7 @@ echo "Cycles: $cycles / 1000 | color=$color href='https://support.apple.com/en-u
 condition=$(system_profiler SPPowerDataType | grep "Condition" | sed -e 's/^.*: //')
 
 color=green
-if [ $condition != "Normal" ]; then
+if [ "$condition" != "Normal" ]; then
     color=red
 fi
 


### PR DESCRIPTION
Was wandering on the other PRs and I found a post from @keithamus about ShellCheck. Thought I should've test my scripts before opening my PRS.
So I tested my battery-cycles Bash script and my currency-tracker Python script through online lint testers ( www.shellcheck.net and www.pep8online.com ) and corrected them.

That's not a **big** fix, but I thinks that's necessary.