### PR TITLE
Added Power Status plugin, to see both power source and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ This repo contains scripts, programs and command-line tools that add functionali
 - USB Device Info
 - Screen Lock
 - Mounted Disk Capacity
+- Power Status/source
 
 #####Battery
 - Battery percentage for bluetooth Mouse
 - Battery percentage for bluetooth Keyboard
 - Battery percentage for bluetooth Trackpad
 - Battery cycles
-
 ####Time
 - Fuzzy clock
 
@@ -120,6 +120,7 @@ Special thanks to everyone who has contributed:
 - Joe Canero - [https://github.com/caneroj1](https://github.com/caneroj1)
 - Goran Gajic - [https://github.com/gorangajic](https://github.com/gorangajic)
 - Thameera Senanayaka - [http://thameera.com](http://thameera.com)
+- Jeff Beadles - [https://github.com/jeffbeadles](https://github.com/jeffbeadles)
 
 ## Add your own plugin
 

--- a/System/power_status.15s.sh
+++ b/System/power_status.15s.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# <bitbar.title>Power Status</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Jeff Beadles</bitbar.author>
+# <bitbar.author.github>jeffbeadles</bitbar.author.github>
+# <bitbar.desc>Shows power source, current mode and settings</bitbar.desc>
+#
+export PATH="/bin:/usr/bin:$PATH"
+
+# AC or Battery?
+pmset -g cap | sed -ne 's/^Capabilities for \(.*\) Power:$/\1/p'
+echo "---"
+# Power setting details
+pmset -g live | \
+   sed -e '1,3d' \
+       -e 's/Currently in use.*$/Current power settings/' \
+       -e 's/$/ | font=Courier color=black size=12/'
+
+exit 0
+#eof


### PR DESCRIPTION
A simple bash script to see the current power supply (battery or ac), and power settings.
