### PR TITLE
Ping time script: indicate individual dead connections in dropdown.

### DIFF
--- a/Network/ping.10s.sh
+++ b/Network/ping.10s.sh
@@ -5,7 +5,7 @@
 # It shows current ping to some servers at the top Menubar
 # This helps me to know my current connection speed
 #
-# Authors: (Trung Đinh Quang) trungdq88@gmail.com and (Grant Sherrick) https://github.com/thealmightygrant 
+# Authors: (Trung Đinh Quang) trungdq88@gmail.com and (Grant Sherrick) https://github.com/thealmightygrant
 
 MAX_PING=10000
 SITES=(google.com youtube.com wikipedia.org github.com imgur.com)
@@ -70,6 +70,13 @@ echo "$MSG | font=UbuntuMono-Bold color=$COLOR size=10"
 echo "---"
 SITE_INDEX=0
 while [ $SITE_INDEX -lt ${#SITES[@]} ]; do
-    echo "${SITES[$SITE_INDEX]}: ${PING_TIMES[$SITE_INDEX]} ms"
+    PING_TIME=${PING_TIMES[$SITE_INDEX]}
+    if [ $PING_TIME -eq $MAX_PING ]; then
+        PING_TIME="☠"
+    else
+        PING_TIME="$PING_TIME ms"
+    fi
+
+    echo "${SITES[$SITE_INDEX]}: $PING_TIME"
     SITE_INDEX=$(( $SITE_INDEX + 1 ))
 done


### PR DESCRIPTION
A quick fix to show the same skull-and-crossbones character in the dropdown for any individual connection that is dead:
<img width="137" alt="fix" src="https://cloud.githubusercontent.com/assets/537241/12271772/b6729062-b911-11e5-8c49-9e805fca8656.png">
