### PR TITLE
Track spending at a UK bank via the menu

### DIFF
--- a/Finance/teller-track-spending.1h.sh
+++ b/Finance/teller-track-spending.1h.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# Teller.io Banking via the OSX menu bar
+# Requires:
+# - a Teller.io account
+# - a UK Bank
+# - teller-cli: https://github.com/sebinsua/teller-cli#from-release
+# - pcregrep: `brew install pcre`
+#
+# <bitbar.title>teller-track-spending</bitbar.title>
+# <bitbar.version>v1.3.1</bitbar.version>
+# <bitbar.author>Seb Insua</bitbar.author>
+# <bitbar.author.github>sebinsua</bitbar.author.github>
+# <bitbar.desc>Track your spending from your menu bar</bitbar.desc>
+# <bitbar.image>https://camo.githubusercontent.com/e0215e6736172334f62effff36ff8df1ab38fed1/687474703a2f2f692e696d6775722e636f6d2f627638545a4c652e706e67</bitbar.image>
+# <bitbar.dependencies>teller-cli, pcregrep</bitbar.dependencies>
+# <bitbar.abouturl>https://github.com/sebinsua/teller-cli</bitbar.abouturl>
+
+export PATH="/usr/local/bin:/usr/bin/:$PATH";
+
+SPENDING_LIMIT='3000.00'; # Change this to a suitable spending limit.
+
+exit_if_zero() {
+  RETURN_CODE=$1;
+  ERROR_MESSAGE=$2;
+  if [ "$ERROR_MESSAGE" = "" ]; then
+    ERROR_MESSAGE="Offline";
+  fi;
+  if [ "$RETURN_CODE" -ne 0 ]; then
+    echo "$ERROR_MESSAGE|color=#7e7e7e";
+    exit 1;
+  fi;
+}
+
+# If we're offline we shouldn't output junk in the menu bar.
+curl --connect-timeout 5 www.google.com > /dev/null 2> /dev/null;
+exit_if_zero $? "Offline";
+
+CURRENT_OUTGOING=$(teller show outgoing current --hide-currency);
+exit_if_zero $? "Error";
+
+CURRENT_BALANCE=$(teller show balance current --hide-currency);
+exit_if_zero $? "Error";
+
+LAST_TRANSACTION=$(teller list transactions | tail -n 1 | pcregrep -o1 "[0-9]+[ ]+(.*)");
+exit_if_zero $? "Error";
+
+if [ "$(echo "$CURRENT_OUTGOING > $SPENDING_LIMIT" | bc)" -ne 0 ]; then
+  OVERSPEND=$(echo "scale=2; $CURRENT_OUTGOING - $SPENDING_LIMIT" | bc);
+  echo "🚨 £$OVERSPEND OVERSPENT|color=red";
+else
+  UNDERSPEND=$(echo "scale=2; $SPENDING_LIMIT - $CURRENT_OUTGOING" | bc);
+  if [ "$(echo "$UNDERSPEND > ($SPENDING_LIMIT/2)" | bc)" -ne 0 ]; then
+    echo "🏦 £$UNDERSPEND remaining|color=green";
+  else
+    echo "🏦 £$UNDERSPEND remaining|color=#ffbf00";
+  fi;
+fi;
+echo "---";
+echo "Current Account: £$CURRENT_BALANCE";
+echo "Current Outgoing: £$CURRENT_OUTGOING";
+echo "Last TX: $LAST_TRANSACTION";


### PR DESCRIPTION
Track spending at a UK bank via the menu bar.

There are a couple of dependencies to this.

1. An account at Teller.io.
2. [teller-cli](https://github.com/sebinsua/teller-cli) setup on your machine.
3. `pcregrep`

[This is what it looks like.](https://twitter.com/nouswaves/status/684396522675527680).

![teller-cli connected to BitBar](https://pbs.twimg.com/media/CX93AprWkAAKeJE.png:large)