### PR TITLE
Add GitHub:Enterprise support to GitHub/notifications.30s.py

### DIFF
--- a/Dev/GitHub/notifications.30s.py
+++ b/Dev/GitHub/notifications.30s.py
@@ -1,30 +1,76 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Github Notifications by Keith Cirkel
-# Fetch Github notifications in your menu bar!
+
+# <bitbar.title>GitHub Notifications</bitbar.title>
+# <bitbar.version>v2.0.0</bitbar.version>
+# <bitbar.author>Keith Cirkel, John Flesch</bitbar.author>
+# <bitbar.author.github>flesch</bitbar.author.github>
+# <bitbar.desc>GitHub (and GitHub:Enterprise) notifications in your menu bar!</bitbar.desc>
+# <bitbar.image>https://cloud.githubusercontent.com/assets/13259/12300782/9f1f5ba8-b9e2-11e5-8e67-e59966aace9a.png</bitbar.image>
+# <bitbar.dependencies>python</bitbar.dependencies>
 
 import json
 import urllib2
 import os
 import re
 
-api_key = os.getenv('GITHUB_TOKEN', 'Please put your GitHub Token here')
-url = 'https://api.github.com/notifications'
+# GitHub.com
+github_api_key = os.getenv( 'GITHUB_TOKEN', 'Enter your GitHub.com Personal Access Token here...' )
 
-request = urllib2.Request( url, headers     = { 'Authorization': 'token ' + api_key } )
-response = urllib2.urlopen( request )
-notifications = json.load( response )
+# GitHub:Enterprise (optional)
+enterprise_api_key = os.getenv( 'GITHUB_ENTERPRISE_TOKEN', 'Enter your GitHub:Enterprise Personal Access Token here...' )
+enterprise_api_url = os.getenv( 'GITHUB_ENTERPRISE_API', 'https://github.example.com/api/v3' )
 
-color = '#7d7d7d'
-if len( notifications ) > 0:
-    color='#4078C0'
+active = '#4078C0'
+inactive = '#7d7d7d'
+
+def get_notifications( api_key, api_url = 'https://api.github.com' ):
+    if len( api_key ) == 40:
+        try:
+            request = urllib2.Request( api_url + '/notifications', headers = { 'Authorization': 'token ' + api_key } )
+            response = urllib2.urlopen( request )
+            notifications = json.load( response )
+            return map(format_notification, notifications)
+        except Exception as e:
+            return []
+    else:
+        return []
+
+def format_notification( notification ):
+    title = notification['subject']['title']
+    repo = notification['repository']['full_name']
+    url = re.sub( 'api\.|api/v3/|repos/', '', notification['subject']['url'] )
+    url = re.sub( '(pull|commit)s', ur'\1', url )
+    return ( '%s: %s | length=90 refresh=true href=%s' % ( repo, title, url ) ).encode( 'utf-8' )
+
+def plural( word, n ):
+    return str(n) + ' ' + (word + 's' if n > 1 else word)
+
+is_github_defined = len( github_api_key ) == 40
+is_github_enterprise_defined = len( enterprise_api_key ) == 40
+
+github_notifications = get_notifications( github_api_key ) if is_github_defined else []
+enterprise_notifications = get_notifications( enterprise_api_key, enterprise_api_url ) if is_github_enterprise_defined else []
+has_notifications = len( github_notifications ) + len( enterprise_notifications )
+
+color = active if has_notifications else inactive
 
 print ( u'\u25CF | color=' + color ).encode( 'utf-8' )
 print '---'
-for notification in notifications:
-    title = notification['subject']['title']
-    repo = notification['repository']['full_name']
-    url = re.sub( '^https://api.github.com/repos/', 'https://github.com/', notification['subject']['url'] )
-    url = re.sub( '/pulls/', '/pull/', url )
-    url = re.sub( '/commits/', '/commit/', url )
-    print ( '%s: %s | refresh=true href=%s' % ( repo, title, url ) ).encode( 'utf-8' )
+
+if is_github_defined:
+    if len( github_notifications ):
+        print ( u'GitHub \u2014 %s | color=%s href=https://github.com/notifications' % ( plural( 'notification', len( github_notifications ) ), active ) ).encode( 'utf-8' )
+        print '\n'.join( github_notifications )
+    else:
+        print ( u'GitHub \u2014 No new notifications | color=%s' % inactive ).encode( 'utf-8' )
+
+if is_github_enterprise_defined:
+    if len( enterprise_notifications ):
+        if is_github_defined:
+            print '---'
+        print ( u'GitHub:Enterprise \u2014 %s | color=%s href=%s/notifications' % ( plural( 'notification', len( enterprise_notifications ) ), active, re.sub( '/api/v3', '',  enterprise_api_url) ) ).encode( 'utf-8' )
+        print '\n'.join( enterprise_notifications )
+    else:
+        print '---'
+        print ( u'GitHub:Enterprise \u2014 No new notifications | color=%s' % inactive ).encode( 'utf-8' )


### PR DESCRIPTION
I added support for fetching **GitHub:Enterprise** notifications. For those of us that use both **GitHub.com** and an enterprise instance, notifications from both places will show up (rather than running a second instance of this plugin with GH:E modifications).

![preview](https://cloud.githubusercontent.com/assets/13259/12300782/9f1f5ba8-b9e2-11e5-8e67-e59966aace9a.png)

If a user doesn't define a GH:E token and API, that section won't show up.