### PR TITLE
Added Bitbar plugin for Google Finance Stocks

### DIFF
--- a/Finance/gfinance.5m.py
+++ b/Finance/gfinance.5m.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# <bitbar.title>Google Finance Stock Ticker</bitbar.title>
+# <bitbar.version>1.4</bitbar.version>
+# <bitbar.author>Jamieson Colburn</bitbar.author>
+# <bitbar.author.github>jamiesonio</bitbar.author.github>
+# <bitbar.desc>Provides a rotating stock ticker in your menu bar</bitbar.desc>
+# <bitbar.image>http://nothingreally.botler.me/bitbar.currency-tracker.png</bitbar.image>
+# <bitbar.dependencies>python</bitbar.dependencies>
+import urllib2
+import json
+import time
+
+#Stocks can be provided with just the symbol (AAPL) or exchange:symbol (NASDAQ:AAPL)
+stocks={"MSFT","AAPL","GOOGL","AMZN","ONDK"}
+
+query = ""
+for i in stocks:
+    query = i + "," + query
+
+url = "http://finance.google.com/finance/info?client=ig&q=" + query
+u = urllib2.urlopen(url)
+query = u.read()
+obj = json.loads(query[4:-1])
+
+for ticker in obj:
+    if float(ticker["c"]) < 0:
+        print ticker["t"], ticker["l"], ticker["c"], "| color=red"
+    elif float(ticker["c"]) > 0:
+        print ticker["t"], ticker["l"], ticker["c"], "| color=green"

--- a/Finance/gfinance.5m.py
+++ b/Finance/gfinance.5m.py
@@ -5,7 +5,7 @@
 # <bitbar.author>Jamieson Colburn</bitbar.author>
 # <bitbar.author.github>jamiesonio</bitbar.author.github>
 # <bitbar.desc>Provides a rotating stock ticker in your menu bar</bitbar.desc>
-# <bitbar.image>http://nothingreally.botler.me/bitbar.currency-tracker.png</bitbar.image>
+# <bitbar.image>https://s3.amazonaws.com/jamieson.io/bitbar_gfinance.png</bitbar.image>
 # <bitbar.dependencies>python</bitbar.dependencies>
 import urllib2
 import json
@@ -24,7 +24,4 @@ query = u.read()
 obj = json.loads(query[4:-1])
 
 for ticker in obj:
-    if float(ticker["c"]) < 0:
-        print ticker["t"], ticker["l"], ticker["c"], "| color=red"
-    elif float(ticker["c"]) > 0:
-        print ticker["t"], ticker["l"], ticker["c"], "| color=green"
+    print "{} {} {} | color=".format(ticker["t"], ticker["l"], ticker["c"]), "red" if float(ticker["c"]) < 0 else "green"


### PR DESCRIPTION
Displays stock tickers from Google Finance, and colors red or green based on where they are trading for the day.

![Screenshot](https://s3.amazonaws.com/jamieson.io/bitbar_gfinance.png)