### PR TITLE
[Music/Spotify] - Truncate long track and artist names

### DIFF
--- a/Music/spotify.10s.sh
+++ b/Music/spotify.10s.sh
@@ -52,15 +52,16 @@ else
 fi
 
 suffix="..."
+trunc_length=20
 track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
 truncated_track=$track
-if [ ${#track} -gt 20 ];then
-  truncated_track=${track:0:18}$suffix
+if [ ${#track} -gt $trunc_length ];then
+  truncated_track=${track:0:$trunc_length-2}$suffix
 fi
 artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
 truncated_artist=$artist
-if [ ${#artist} -gt 20 ];then
-  truncated_artist=${artist:0:18}$suffix
+if [ ${#artist} -gt $trunc_length ];then
+  truncated_artist=${artist:0:$trunc_length-2}$suffix
 fi
 album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
 

--- a/Music/spotify.10s.sh
+++ b/Music/spotify.10s.sh
@@ -54,12 +54,12 @@ fi
 suffix="..."
 track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
 truncated_track=$track
-if [ ${#track} -gt 18 ];then
+if [ ${#track} -gt 20 ];then
   truncated_track=${track:0:18}$suffix
 fi
 artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
 truncated_artist=$artist
-if [ ${#artist} -gt 18 ];then
+if [ ${#artist} -gt 20 ];then
   truncated_artist=${artist:0:18}$suffix
 fi
 album=`osascript -e 'tell application "Spotify" to album of current track as string'`;

--- a/Music/spotify.10s.sh
+++ b/Music/spotify.10s.sh
@@ -56,12 +56,12 @@ trunc_length=20
 track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
 truncated_track=$track
 if [ ${#track} -gt $trunc_length ];then
-  truncated_track=${track:0:$trunc_length-2}$suffix
+  truncated_track=${track:0:$trunc_length-${#suffic}}$suffix
 fi
 artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
 truncated_artist=$artist
 if [ ${#artist} -gt $trunc_length ];then
-  truncated_artist=${artist:0:$trunc_length-2}$suffix
+  truncated_artist=${artist:0:$trunc_length-${#suffic}}$suffix
 fi
 album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
 

--- a/Music/spotify.10s.sh
+++ b/Music/spotify.10s.sh
@@ -51,11 +51,20 @@ else
   state_icon="❚❚"
 fi
 
+suffix="..."
 track=`osascript -e 'tell application "Spotify" to name of current track as string'`;
+truncated_track=$track
+if [ ${#track} -gt 18 ];then
+  truncated_track=${track:0:18}$suffix
+fi
 artist=`osascript -e 'tell application "Spotify" to artist of current track as string'`;
+truncated_artist=$artist
+if [ ${#artist} -gt 18 ];then
+  truncated_artist=${artist:0:18}$suffix
+fi
 album=`osascript -e 'tell application "Spotify" to album of current track as string'`;
 
-echo $state_icon $track - $artist
+echo $state_icon $truncated_track - $truncated_artist
 echo "---"
 
 case "$0" in


### PR DESCRIPTION
I found some very long track and artist names taking up my whole bar.  This change truncates long ones in the menubar, and leaves the full display when open if you're curious.  