### PR TITLE
[UsbInfo Plugin] fix color and open System Information on click

### DIFF
--- a/System/usbInfo.10s.py
+++ b/System/usbInfo.10s.py
@@ -18,9 +18,9 @@ def findDevices(itemList):
         elif 'Built-in_Device' in device and device['Built-in_Device'] == 'Yes':
             continue
         else:
-            print "Name:\t\t\t" + device['_name'] + '| color=white'
+            print "Name:\t\t\t" + device['_name'] + '| bash=/usr/bin/open param1="/Applications/Utilities/System Information.app" terminal=false'
             if 'manufacturer' in device:
-                print "Manufacturer:\t" + device['manufacturer'] + '| color=white'
+                print "Manufacturer:\t" + device['manufacturer'] + '| bash=/usr/bin/open param1="/Applications/Utilities/System Information.app" terminal=false'
             print '---'
 
 usbPlist = subprocess.check_output(['system_profiler', '-xml', 'SPUSBDataType'])


### PR DESCRIPTION
Previously color was hardcoded in white, which only shows in osx dark mode. Now shows in both mode.
Also opening System Information App on clicking a device