### PR TITLE
Rewrote the uptime plugin for easier customization

### DIFF
--- a/System/uptime.1m.sh
+++ b/System/uptime.1m.sh
@@ -9,20 +9,6 @@
 
 INFO=`uptime`
 echo $INFO | awk -F'[ ,:\t\n]+' '
-    function include(VAL, UNIT, SUFFIX, PLURAL) {
-        VAL = int(VAL)
-
-        if (PLURAL && VAL > 1) {
-            UNIT = UNIT"s"
-        }
-
-        if (VAL > 0) {
-            return (VAL UNIT SUFFIX)
-        } else {
-            return ""
-        }
-    }
-
     {
         PLURAL = 1
 
@@ -71,6 +57,19 @@ echo $INFO | awk -F'[ ,:\t\n]+' '
         MSG = substr(MSG, 0, length(MSG) - length(SEP))
 
         print "[", MSG, "] | size=12"
+    }
+    function include(VAL, UNIT, SUFFIX, PLURAL) {
+        VAL = int(VAL)
+
+        if (PLURAL && VAL > 1) {
+            UNIT = UNIT"s"
+        }
+
+        if (VAL > 0) {
+            return (VAL UNIT SUFFIX)
+        } else {
+            return ""
+        }
     }'
 
 echo "---"

--- a/System/uptime.1m.sh
+++ b/System/uptime.1m.sh
@@ -24,6 +24,17 @@ echo $INFO | awk -F'[ ,:\t\n]+' '
     }
 
     {
+        PLURAL = 1
+
+        SEP = ", "
+
+        DS = " day"
+        HS = " hr"
+        MS = " min"
+        SS = " sec"
+
+        ################################
+
         D = H = M = S = 0
 
         if (substr($5,0,1) == "d") {
@@ -51,28 +62,10 @@ echo $INFO | awk -F'[ ,:\t\n]+' '
             M = Q
         }
 
-        LONG = 1
-
-        if (LONG) {
-            SEP = ", "
-
-            DS = " day"
-            HS = " hr"
-            MS = " min"
-            SS = " sec"
-        } else {
-            SEP = " : "
-
-            DS = "d"
-            HS = "h"
-            MS = "m"
-            SS = "s"
-        }
-
-        MSG = "↑ " include(D, DS, SEP, LONG) \
-                   include(H, HS, SEP, LONG) \
-                   include(M, MS, SEP, LONG) \
-                   include(S, SS, SEP, LONG)
+        MSG = "↑ " include(D, DS, SEP, PLURAL) \
+                   include(H, HS, SEP, PLURAL) \
+                   include(M, MS, SEP, PLURAL) \
+                   include(S, SS, SEP, PLURAL)
 
         # remove the remaining SEP
         MSG = substr(MSG, 0, length(MSG) - length(SEP))

--- a/System/uptime.1m.sh
+++ b/System/uptime.1m.sh
@@ -11,6 +11,7 @@ INFO=`uptime`
 echo $INFO | awk -F'[ ,:\t\n]+' '
     {
         PLURAL = 1
+        VERBOSE = 0
 
         SEP = ", "
 
@@ -49,8 +50,8 @@ echo $INFO | awk -F'[ ,:\t\n]+' '
         }
 
         MSG = "↑ " include(D, DS, SEP, PLURAL) \
-                   include(H, HS, SEP, PLURAL) \
-                   include(M, MS, SEP, PLURAL) \
+                   include(H, HS, SEP, PLURAL, (D > 0 && VERBOSE)) \
+                   include(M, MS, SEP, PLURAL, (D > 0 && VERBOSE)) \
                    include(S, SS, SEP, PLURAL)
 
         # remove the remaining SEP
@@ -58,17 +59,18 @@ echo $INFO | awk -F'[ ,:\t\n]+' '
 
         print "[", MSG, "] | size=12"
     }
-    function include(VAL, UNIT, SUFFIX, PLURAL) {
+
+    function include(VAL, UNIT, SUFFIX, PLURAL, VERBOSE) {
         VAL = int(VAL)
 
-        if (PLURAL && VAL > 1) {
+        if (PLURAL && VAL != 1) {
             UNIT = UNIT"s"
         }
 
-        if (VAL > 0) {
+        if (VAL > 0 || VERBOSE) {
             return (VAL UNIT SUFFIX)
         } else {
-            return ""
+            # return ""
         }
     }'
 

--- a/System/uptime.1m.sh
+++ b/System/uptime.1m.sh
@@ -7,8 +7,8 @@
 # <bitbar.desc>Show uptime command information.</bitbar.desc>
 # <bitbar.image>http://i.imgur.com/qaIxpJN.png</bitbar.image>
 
-INFO=`uptime`
-echo $INFO | awk -F'[ ,:\t\n]+' '
+INFO=$(uptime)
+echo "$INFO" | awk -F'[ ,:\t\n]+' '
     {
         PLURAL = 1
         VERBOSE = 0
@@ -49,10 +49,10 @@ echo $INFO | awk -F'[ ,:\t\n]+' '
             M = Q
         }
 
-        MSG = "↑ " include(D, DS, SEP, PLURAL) \
-                   include(H, HS, SEP, PLURAL, (D > 0 && VERBOSE)) \
-                   include(M, MS, SEP, PLURAL, (D > 0 && VERBOSE)) \
-                   include(S, SS, SEP, PLURAL)
+        MSG = "↑ " include(D, DS, SEP, PLURAL)
+        MSG = MSG  include(H, HS, SEP, PLURAL, (D > 0 && VERBOSE))
+        MSG = MSG  include(M, MS, SEP, PLURAL, (D > 0 && VERBOSE))
+        MSG = MSG  include(S, SS, SEP, PLURAL)
 
         # remove the remaining SEP
         MSG = substr(MSG, 0, length(MSG) - length(SEP))
@@ -75,4 +75,4 @@ echo $INFO | awk -F'[ ,:\t\n]+' '
     }'
 
 echo "---"
-echo $INFO | tr "," "\n" | tail -n 2
+echo "$INFO" | tr "," "\n" | tail -n 2


### PR DESCRIPTION
Added *flags* `PLURAL` for plural or singular output, and `VERBOSE` for including some values even when they are 0.
The variables `DS`, `HS`, `MS`, `SS` and `SEP` can be modified to change the output to own preference.

**** 

As an example, the user may prefer:

    PLURAL = 0

    SEP = " : "

    DS = "d"
    HS = "h"
    MS = "m"
    SS = "s"

To get output like:
> [ ↑ 2d : 10h : 5m ]

****

Or in another language, in spanish:

    PLURAL = 1

    SEP = ", "

    DS = " día"
    HS = " hora"
    MS = " minuto"
    SS = " segundo"

To get output like:
> [ ↑ 2 días, 10 horas, 5 minutos ]