### PR TITLE
Refresh count of brew updates after click

### DIFF
--- a/Dev/Homebrew/brew-updates.1h.sh
+++ b/Dev/Homebrew/brew-updates.1h.sh
@@ -18,6 +18,6 @@ UPDATE_COUNT=$(echo "$UPDATES" | grep -c '[^[:space:]]');
 echo "↑$UPDATE_COUNT | dropdown=false"
 echo "---";
 if [ -n "$UPDATES" ]; then
-  echo "Upgrade all | bash=/usr/local/bin/brew param1=upgrade"
-  echo "$UPDATES" | awk '{print $0 " | bash=/usr/local/bin/brew param1=upgrade param2=" $1 }'
+  echo "Upgrade all | bash=/usr/local/bin/brew param1=upgrade terminal=false refresh=true"
+  echo "$UPDATES" | awk '{print $0 " | terminal=false refresh=true bash=/usr/local/bin/brew param1=upgrade param2=" $1}'
 fi


### PR DESCRIPTION
Currently the number of updates available doesn't refresh after you make a change (ie click Upgrade All or upgrade a specific package). You have to wait for the cron to fire again or manually refresh once the update is done.

This changes it so it refreshes after brew completes your update. The downside is that you can't see what the terminal is doing, and so if something went wrong for some reason you wouldn't notice.

IMO this is better (it's what I use locally) but that's personal preference.