### PR TITLE
Add Virtualbox Running VMs plugin

### DIFF
--- a/Dev/Virtualbox/virtualbox-running_vms.30s.rb
+++ b/Dev/Virtualbox/virtualbox-running_vms.30s.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+# Show running Virtualbox VMs with option to shutdown (save state) using VBoxManage.
+#
+# <bitbar.title>Virtualbox running VMs</bitbar.title>
+# <bitbar.version>1.0</bitbar.version>
+# <bitbar.author>Harald Ringvold</bitbar.author>
+# <bitbar.author.github>haraldringvold</bitbar.author.github>
+# <bitbar.desc>Show running virtualbox VMs with option to shutdown (save state) using VBoxManage.</bitbar.desc>
+# <bitbar.image>http://i.imgur.com/YmFrYQH.png</bitbar.image>
+# <bitbar.dependencies>Ruby,VBoxManage</bitbar.dependencies>
+
+
+ENV['PATH'] = ENV['PATH']+':/usr/local/bin';
+
+status = `VBoxManage list runningvms`;
+
+if status != ""
+  vms = status.split(/\n/);
+
+  print "🇻"
+  print "#{vms.length}" if vms
+  puts ""
+  puts "---"
+
+  vms.each do |vm|
+    data_image = /('.*?'|".*?"|\S+).({.*?})/.match vm
+    name = data_image[1].tr!('"','');
+    id = data_image[2].tr!('{}','');
+
+    puts "#{name}| color=black";
+    puts "#{id}";
+    puts "Save | color=green bash=VBoxManage  param1=controlvm param2=#{id} param3=savestate"
+    puts "---";
+  end
+else
+  # if no VMs are running
+  puts "🇻";
+end
+

--- a/Dev/Virtualbox/virtualbox-running_vms.30s.rb
+++ b/Dev/Virtualbox/virtualbox-running_vms.30s.rb
@@ -11,12 +11,12 @@
 # <bitbar.dependencies>Ruby,VBoxManage</bitbar.dependencies>
 
 
-ENV['PATH'] = ENV['PATH']+':/usr/local/bin';
+ENV['PATH'] = ENV['PATH']+':/usr/local/bin'
 
-status = `VBoxManage list runningvms`;
+status = `VBoxManage list runningvms`
 
 if status != ""
-  vms = status.split(/\n/);
+  vms = status.split(/\n/)
 
   print "🇻"
   print "#{vms.length}" if vms
@@ -25,16 +25,16 @@ if status != ""
 
   vms.each do |vm|
     data_image = /('.*?'|".*?"|\S+).({.*?})/.match vm
-    name = data_image[1].tr!('"','');
-    id = data_image[2].tr!('{}','');
+    name = data_image[1].tr('"','')
+    id = data_image[2].tr('{}','')
 
-    puts "#{name}| color=black";
-    puts "#{id}";
+    puts "#{name}| color=black"
+    puts "#{id}"
     puts "Save | color=green bash=VBoxManage  param1=controlvm param2=#{id} param3=savestate"
-    puts "---";
+    puts "---"
   end
 else
   # if no VMs are running
-  puts "🇻";
+  puts "🇻"
 end
 


### PR DESCRIPTION
A plugin to display and shut down (save) running Virtualbox VMs.

Got the idea from vagrant.30s.pl. I have VMs that are not in vagrant and I am most interested in seeing if there is any VMs running when they dont need to.