### PR TITLE
Get rid of Spotify's redundant info from track title

### DIFF
--- a/Music/nowplaying.5s.sh
+++ b/Music/nowplaying.5s.sh
@@ -91,7 +91,7 @@ else
 	track=$(osascript -e "tell application \"$app\" to $track_query")
 	artist=$(osascript -e "tell application \"$app\" to $artist_query")
 
-	echo "$track | length=40"
+	echo "$track | length=40" | awk -F '\ -' '{print $1}'
 	echo "---"
 	echo "$artist"
 


### PR DESCRIPTION
e.g.:
" - 2012 Remastered Version"
" - Single Version"