### PR TITLE
Truncated exchange rate to 2 decimal places

### DIFF
--- a/Finance/transferwise-currency-tracker.1m.py
+++ b/Finance/transferwise-currency-tracker.1m.py
@@ -27,6 +27,6 @@ req.add_header('X-Authorization-key', TRANSFERWISE_KEY)
 
 result = json.loads(urllib2.urlopen(req).read())['transferwiseRate']
 
-print "{}: {}".format(currency_to, result)
+print "{}: {:.2f}".format(currency_to, result)
 print "---"
 print "From: {}".format(currency_from)


### PR DESCRIPTION
Sometimes Transferwise returns exchange rates to 7-8 decimal places, which pollutes the bar.