### PR TITLE
Added exception handling for ip-flag

### DIFF
--- a/Network/ip-flag.2m.rb
+++ b/Network/ip-flag.2m.rb
@@ -13,7 +13,7 @@ begin
   country_code = open('http://ipinfo.io/country').string.chomp.split ''
   c1, c2 = *country_code.map { |c| (c.ord + 0x65).chr.force_encoding 'UTF-8' }
   puts "\xF0\x9F\x87#{c1}\xF0\x9F\x87#{c2}"
-rescue Exception => err
+rescue StandardError => err
   puts "🚩"
   puts "---"
   puts err.to_s

--- a/Network/ip-flag.2m.rb
+++ b/Network/ip-flag.2m.rb
@@ -9,6 +9,12 @@
 
 require 'open-uri'
 
-country_code = open('http://ipinfo.io/country').string.chomp.split ''
-c1, c2 = *country_code.map { |c| (c.ord + 0x65).chr.force_encoding 'UTF-8' }
-puts "\xF0\x9F\x87#{c1}\xF0\x9F\x87#{c2}"
+begin
+  country_code = open('http://ipinfo.io/country').string.chomp.split ''
+  c1, c2 = *country_code.map { |c| (c.ord + 0x65).chr.force_encoding 'UTF-8' }
+  puts "\xF0\x9F\x87#{c1}\xF0\x9F\x87#{c2}"
+rescue Exception => err
+  puts "🚩"
+  puts "---"
+  puts err.to_s
+end


### PR DESCRIPTION
This is for when there's no internet connection or stuff like that.

We could use 🚩 or 🏁, since they're flags that do not belong to a country. I prefered 🚩 because red is used for warnings / errors.