### PR TITLE
add Average Review Times Plugin

### DIFF
--- a/Web/AppStore/average_app_store_review_times.rb
+++ b/Web/AppStore/average_app_store_review_times.rb
@@ -6,9 +6,9 @@
 # <bitbar.author>mfks17</bitbar.author>
 # <bitbar.author.github>mfks17</bitbar.author.github>
 # <bitbar.desc>Average App Store Review Times</bitbar.desc>
-# <bitbar.image>https://github.com/mfks17/bitbar-plugins/blob/master/Screenshots/01.png</bitbar.image>
+# <bitbar.image>https://github.com/mfks17/bitbar-plugin-AppStore/blob/master/Screenshots/01.png</bitbar.image>
 # <bitbar.dependencies>ruby, nokogiri</bitbar.dependencies>
-# <bitbar.abouturl>https://github.com/mfks17/bitbar-plugins</bitbar.abouturl>
+# <bitbar.abouturl>https://github.com/mfks17/bitbar-plugin-AppStore</bitbar.abouturl>
 
 require 'open-uri'
 require 'nokogiri'

--- a/Web/AppStore/average_app_store_review_times.rb
+++ b/Web/AppStore/average_app_store_review_times.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
+
+# <bitbar.title>Average Reivew Times</bitbar.title>
+# <bitbar.version>v0.1.2</bitbar.version>
+# <bitbar.author>mfks17</bitbar.author>
+# <bitbar.author.github>mfks17</bitbar.author.github>
+# <bitbar.desc>Average App Store Review Times</bitbar.desc>
+# <bitbar.image>https://github.com/mfks17/bitbar-plugins/blob/master/Screenshots/01.png</bitbar.image>
+# <bitbar.dependencies>ruby, nokogiri</bitbar.dependencies>
+# <bitbar.abouturl>https://github.com/mfks17/bitbar-plugins</bitbar.abouturl>
+
+require 'open-uri'
+require 'nokogiri'
+
+url = 'http://appreviewtimes.com/'
+
+charset = nil
+html = open(url) do |f|
+  charset = f.charset
+  f.read
+end
+
+doc = Nokogiri::HTML.parse(html, nil, charset)
+
+puts 'Average Review Times'
+puts '---'
+puts '📱  iOS App Store ' + doc.xpath('/html/body/div[2]/div/div[2]/div[1]/p[1]').text
+
+puts '💻  Mac App Store ' + doc.xpath('/html/body/div[2]/div/div[3]/div[1]/p[1]').text

--- a/Web/AppStore/average_app_store_review_times.rb
+++ b/Web/AppStore/average_app_store_review_times.rb
@@ -6,7 +6,7 @@
 # <bitbar.author>mfks17</bitbar.author>
 # <bitbar.author.github>mfks17</bitbar.author.github>
 # <bitbar.desc>Average App Store Review Times</bitbar.desc>
-# <bitbar.image>https://github.com/mfks17/bitbar-plugin-AppStore/blob/master/Screenshots/01.png</bitbar.image>
+# <bitbar.image>https://raw.githubusercontent.com/mfks17/bitbar-plugin-AppStore/master/Screenshots/01.png</bitbar.image>
 # <bitbar.dependencies>ruby, nokogiri</bitbar.dependencies>
 # <bitbar.abouturl>https://github.com/mfks17/bitbar-plugin-AppStore</bitbar.abouturl>
 


### PR DESCRIPTION
This is a plugin to show average review times iOS & Mac App Store.
See also [my repository](https://github.com/mfks17/bitbar-plugin-AppStore).