### PR TITLE
Spotify improvements

### DIFF
--- a/Music/spotify.10s.sh
+++ b/Music/spotify.10s.sh
@@ -90,3 +90,6 @@ if [ "$state" = "playing" ]; then
 else
   echo "Play | bash=$0 param1=playpause terminal=false"
 fi
+
+echo '---'
+echo "Open Spotify | bash=$0 param1=launch terminal=false"

--- a/Music/spotify.10s.sh
+++ b/Music/spotify.10s.sh
@@ -15,8 +15,12 @@
 # <bitbar.desc>Display currently playing Spotify song. Play/pause, skip forward, skip backward.</bitbar.desc>
 # <bitbar.image>http://i.imgur.com/y1SZwfq.png</bitbar.image>
 
+function tellspotify() {
+  osascript -e "tell application \"Spotify\" to $1"
+}
+
 if [ "$1" = 'launch' ]; then
-  osascript -e 'tell application "Spotify" to activate'
+  tellspotify 'activate'
   exit
 fi
 
@@ -28,22 +32,13 @@ if [ "$(osascript -e 'application "Spotify" is running')" = "false" ]; then
   exit
 fi
 
-if [ "$1" = 'playpause' ]; then
-  osascript -e 'tell application "Spotify" to playpause'
-  exit
-fi
+case "$1" in
+  'playpause' | 'previous track' | 'next track')
+    tellspotify "$1"
+    exit
+esac
 
-if [ "$1" = 'previous' ]; then
-  osascript -e 'tell application "Spotify" to previous track'
-  exit
-fi
-
-if [ "$1" = 'next' ]; then
-  osascript -e 'tell application "Spotify" to next track';
-  exit
-fi
-
-state=$(osascript -e 'tell application "Spotify" to player state as string');
+state=$(tellspotify 'player state as string');
 
 if [ "$state" = "playing" ]; then
   state_icon="▶"
@@ -53,17 +48,17 @@ fi
 
 suffix="..."
 trunc_length=20
-track=$(osascript -e 'tell application "Spotify" to name of current track as string');
+track=$(tellspotify 'name of current track as string');
 truncated_track=$track
 if [ ${#track} -gt $trunc_length ];then
   truncated_track=${track:0:$trunc_length-${#suffic}}$suffix
 fi
-artist=$(osascript -e 'tell application "Spotify" to artist of current track as string');
+artist=$(tellspotify 'artist of current track as string');
 truncated_artist=$artist
 if [ ${#artist} -gt $trunc_length ];then
   truncated_artist=${artist:0:$trunc_length-${#suffic}}$suffix
 fi
-album=$(osascript -e 'tell application "Spotify" to album of current track as string');
+album=$(tellspotify 'album of current track as string');
 
 echo "$state_icon $truncated_track - $truncated_artist"
 echo "---"
@@ -85,8 +80,8 @@ echo '---'
 
 if [ "$state" = "playing" ]; then
   echo "Pause | bash=$0 param1=playpause terminal=false"
-  echo "Previous | bash=$0 param1=previous terminal=false"
-  echo "Next | bash=$0 param1=next terminal=false"
+  echo "Previous | bash=$0 param1='previous track' terminal=false"
+  echo "Next | bash=$0 param1='next track' terminal=false"
 else
   echo "Play | bash=$0 param1=playpause terminal=false"
 fi


### PR DESCRIPTION
- Missed the ability to quickly switch to the Spotify application from the menulet. This was easily fixed by "relaunching" the application.

Cleaned up the code a little by
- Making one function, `tellspotify`, that will handle every Applescript `tell application "Spotify" to X` interaction. Used in multiple places.
- Removing multiple if statements in favor of a case switch.