### PR TITLE
Adding a single-click python plugin to run caffeinate

### DIFF
--- a/System/stayawake.1h.py
+++ b/System/stayawake.1h.py
@@ -6,7 +6,7 @@
 # <bitbar.author>Christoph Russ</bitbar.author>
 # <bitbar.author.github>christophruss</bitbar.author.github>
 # <bitbar.desc>Keep your computer awake with a single click.</bitbar.desc>
-# <bitbar.image>https://imgur.com/pkqXw8x</bitbar.image>
+# <bitbar.image>http://i.imgur.com/pkqXw8x.jpg</bitbar.image>
 # <bitbar.dependencies>python</bitbar.dependencies>
 # <bitbar.abouturl></bitbar.abouturl>
 

--- a/System/stayawake.1h.py
+++ b/System/stayawake.1h.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# <bitbar.title>Stay Awake</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Christoph Russ</bitbar.author>
+# <bitbar.author.github>christophruss</bitbar.author.github>
+# <bitbar.desc>Keep your computer awake with a single click.</bitbar.desc>
+# <bitbar.image></bitbar.image>
+# <bitbar.dependencies>python</bitbar.dependencies>
+# <bitbar.abouturl></bitbar.abouturl>
+
+import sys
+import time
+import subprocess
+
+def run_detached(cmd):
+    p = subprocess.Popen(cmd, shell=False,
+        stdin=None, stdout=None, stderr=None, close_fds=True)
+
+if len(sys.argv) > 1:
+    if 'start' in sys.argv:
+        run_detached(['/usr/bin/caffeinate','-ids'])
+    exit()
+
+stay_awake = False
+
+caffeinate_running = subprocess.check_output('/bin/ps aux', shell=True).strip().split('\n') # | grep caffeinate
+
+for ps_line in caffeinate_running:
+    if 'caffeinate' in ps_line:
+        stay_awake = True
+
+#'font=Arial' # 'size=12' 'size=14' 'size=9' # ☕ # ⚡ # 💡 # 🚨  m,.
+# :coffee: # :tea: # :sparkles: # :dizzy: # :zzz: # :runner: :running: # :eyes: # :bulb: #:sunny: #:cloud: # :zap:
+# :low_brightness: :high_brightness: :lock: # :unlock: # :rotating_light:
+
+if stay_awake:
+    print '☕ | size=14 refresh=true bash=/usr/bin/killall param1=caffeinate terminal=false'
+else:
+    print '☕ | size=9 refresh=true bash=/usr/bin/python param1='+__file__+' param2=start terminal=false'

--- a/System/stayawake.1h.py
+++ b/System/stayawake.1h.py
@@ -6,16 +6,15 @@
 # <bitbar.author>Christoph Russ</bitbar.author>
 # <bitbar.author.github>christophruss</bitbar.author.github>
 # <bitbar.desc>Keep your computer awake with a single click.</bitbar.desc>
-# <bitbar.image></bitbar.image>
+# <bitbar.image>https://imgur.com/pkqXw8x</bitbar.image>
 # <bitbar.dependencies>python</bitbar.dependencies>
 # <bitbar.abouturl></bitbar.abouturl>
 
 import sys
-import time
 import subprocess
 
 def run_detached(cmd):
-    p = subprocess.Popen(cmd, shell=False,
+    subprocess.Popen(cmd, shell=False,
         stdin=None, stdout=None, stderr=None, close_fds=True)
 
 if len(sys.argv) > 1:


### PR DESCRIPTION
Even though there already are two caffeinate plugins - I am submitting this pull request to add an option that is using the single-click-action feature. It is a very simplistic approach that allows you with a single click to either keep your computer awake or allow it to go to sleep.