### PR TITLE
fix(github/notifications): render correct release urls

### DIFF
--- a/Dev/GitHub/notifications.30s.py
+++ b/Dev/GitHub/notifications.30s.py
@@ -36,11 +36,23 @@ def get_notifications( api_key, api_url = 'https://api.github.com' ):
     else:
         return []
 
+def get_release_url( release ):
+    try:
+        request = urllib2.Request( release, headers = { 'Authorization': 'token ' + github_api_key } )
+        response = urllib2.urlopen( request )
+        return json.load( response )['html_url']
+    except Exception:
+        return release
+
 def format_notification( notification ):
     title = notification['subject']['title']
     repo = notification['repository']['full_name']
-    url = re.sub( 'api\.|api/v3/|repos/', '', notification['subject']['url'] )
-    url = re.sub( '(pull|commit)s', ur'\1', url )
+    url = notification['subject']['url']
+    if 'releases/' in url:
+        url = get_release_url( url )
+    else:
+        url = re.sub( 'api\.|api/v3/|repos/', '', notification['subject']['url'] )
+        url = re.sub( '(pull|commit)s', ur'\1', url )
     return ( '%s: %s | length=90 refresh=true href=%s' % ( repo, title, url ) ).encode( 'utf-8' )
 
 def plural( word, n ):


### PR DESCRIPTION
The release urls in the nofications api are actually the API release ID, they look like
`https://api.github.com/{repos}/{owner}/repo/releases/{release_id}`. Stripping the `api.`
and `/repo` parts just makes a URL that 404s. The actual html page follows a different
format, namely `https://github.com/{owner}/{repo}/releases/{tag}`.

Seemingly the only way to properly get the html url is to fetch the api of the particular
release and extract the `html_url`.