### PR TITLE
Fix wc output to show count only.

### DIFF
--- a/System/clipboard-history.3s.sh
+++ b/System/clipboard-history.3s.sh
@@ -84,7 +84,7 @@ if [[ -e "$tmp_dir/item-1.pb" ]]; then
   do
     if [ -e "$tmp_dir/item-$i.pb" ]; then
       content="$(head -c 36 "$tmp_dir/item-$i.pb")"
-      if (( $(cat "$tmp_dir/item-$i.pb" | wc -c) > 36 )); then
+      if (( $(wc -c "$tmp_dir/item-$i.pb" | awk '{print $1}') > 36 )); then
         content="$content..."
       fi
       echo "${content//|/ }|bash=$0 param1=copy param2=$i refresh=true terminal=false"

--- a/System/clipboard-history.3s.sh
+++ b/System/clipboard-history.3s.sh
@@ -84,7 +84,7 @@ if [[ -e "$tmp_dir/item-1.pb" ]]; then
   do
     if [ -e "$tmp_dir/item-$i.pb" ]; then
       content="$(head -c 36 "$tmp_dir/item-$i.pb")"
-      if (( $(wc -c "$tmp_dir/item-$i.pb") > 36 )); then
+      if (( $(cat "$tmp_dir/item-$i.pb" | wc -c) > 36 )); then
         content="$content..."
       fi
       echo "${content//|/ }|bash=$0 param1=copy param2=$i refresh=true terminal=false"


### PR DESCRIPTION
On my systems wc -c file was also outputting the filename with the count and caused the script to fail the numeric compare.