### PR TITLE
New plugin: List of live twitch streamers that you follow

### DIFF
--- a/Web/Twitch/livestreamer-now-playing.5m.js
+++ b/Web/Twitch/livestreamer-now-playing.5m.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env /usr/local/bin/node
+
+// <bitbar.title>Twitch Following</bitbar.title>
+// <bitbar.version>v1.0</bitbar.version>
+// <bitbar.author>Stefan du Fresne</bitbar.author>
+// <bitbar.author.github>SCdF</bitbar.author.github>
+// <bitbar.desc>Shows the live channels that you follow and lets you watc them with livestreamer. Based on play-with-livestreamer</bitbar.desc>
+// <bitbar.image>https://i.imgur.com/PznEQCt.png</bitbar.image>
+// <bitbar.dependencies>node, livestreamer</bitbar.dependencies>
+
+var LIVESTREAMER_PATH = '/usr/local/bin/livestreamer';
+var LIVESTREAMER_CONFIG_PATH = process.env.HOME + '/.config/livestreamer/config';
+var AUTH_PROP_KEY = 'twitch-oauth-token';
+var ACCESS_TOKEN = readAccessToken();
+
+function readAccessToken() {
+    try {
+        var data = require('fs').readFileSync(LIVESTREAMER_CONFIG_PATH, 'utf8');
+        if (data) {
+            var line = data.split('\n').find(function(line) {
+                return line.indexOf(AUTH_PROP_KEY) >= 0;
+            });
+
+            return line.substring(line.indexOf('=') + 1);
+        }
+    } catch (e) {}
+}
+
+if (ACCESS_TOKEN) {
+    var urlHost = 'api.twitch.tv'
+    var urlPath = '/kraken/streams/followed?stream_type=live'
+    var icon = '👾';
+    var STATUS_LENGTH = 25;
+
+    function handleResponse(body) {
+        var streamByGame = {};
+        for(stream of body.streams) {
+            if (!streamByGame[stream.channel.game]) {
+                streamByGame[stream.channel.game] = [];
+            }
+
+            streamByGame[stream.channel.game].push(stream);
+        }
+
+        var outputs = [];
+
+        for (game in streamByGame) {
+            outputs.push(['', game, '| size=10 \n', streamByGame[game].map(function(stream) {
+                var channel = stream.channel;
+                var url = channel.url.replace('http://',    '');
+                return  [channel.display_name, ' | size=12 terminal=false bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('') +
+                        ['[', stream.viewers, '] ', channel.status, '| size=12 alternate=true length=30 bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('');
+            }).join('')].join(''));
+        }
+
+        console.log(
+            icon + ' ' +
+            (body.streams.length > 0 ? body.streams.length : '') +
+            '\n---\n' +
+            outputs.join('\n---\n'));
+    }
+
+    require('https').get({
+        hostname: urlHost,
+        path: urlPath,
+        headers: {
+            'Authorization': 'OAuth ' + ACCESS_TOKEN
+        }
+    }, function(res) {
+        var body = '';
+        res.on('data', function(data) {
+            body += data;
+        });
+        res.on('end', function() {
+            handleResponse(JSON.parse(body));
+        });
+    });
+} else {
+    console.log('💔');
+    console.log('---');
+    console.log('Click to authenticate livestreamer | terminal=false bash=' + LIVESTREAMER_PATH + ' param1=--twitch-oauth-authenticate');
+}

--- a/Web/Twitch/livestreamer-now-playing.5m.js
+++ b/Web/Twitch/livestreamer-now-playing.5m.js
@@ -26,39 +26,39 @@ function readAccessToken() {
     } catch (e) {}
 }
 
+function handleResponse(body) {
+    var streamByGame = {};
+    body.streams.forEach(function(stream) {
+        if (!streamByGame[stream.channel.game]) {
+            streamByGame[stream.channel.game] = [];
+        }
+
+        streamByGame[stream.channel.game].push(stream);
+    });
+
+    var outputs = [];
+
+    for (game in streamByGame) {
+        outputs.push(['', game, '| size=10 \n', streamByGame[game].map(function(stream) {
+            var channel = stream.channel;
+            var url = channel.url.replace('http://',    '');
+            return  [channel.display_name, ' | size=12 terminal=false bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('') +
+                    ['[', stream.viewers, '] ', channel.status, '| size=12 alternate=true length=30 bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('');
+        }).join('')].join(''));
+    }
+
+    console.log(
+        icon + ' ' +
+        (body.streams.length > 0 ? body.streams.length : '') +
+        '\n---\n' +
+        outputs.join('\n---\n'));
+}
+
 if (ACCESS_TOKEN) {
-    var urlHost = 'api.twitch.tv'
-    var urlPath = '/kraken/streams/followed?stream_type=live'
+    var urlHost = 'api.twitch.tv';
+    var urlPath = '/kraken/streams/followed?stream_type=live';
     var icon = '👾';
     var STATUS_LENGTH = 25;
-
-    function handleResponse(body) {
-        var streamByGame = {};
-        for(stream of body.streams) {
-            if (!streamByGame[stream.channel.game]) {
-                streamByGame[stream.channel.game] = [];
-            }
-
-            streamByGame[stream.channel.game].push(stream);
-        }
-
-        var outputs = [];
-
-        for (game in streamByGame) {
-            outputs.push(['', game, '| size=10 \n', streamByGame[game].map(function(stream) {
-                var channel = stream.channel;
-                var url = channel.url.replace('http://',    '');
-                return  [channel.display_name, ' | size=12 terminal=false bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('') +
-                        ['[', stream.viewers, '] ', channel.status, '| size=12 alternate=true length=30 bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('');
-            }).join('')].join(''));
-        }
-
-        console.log(
-            icon + ' ' +
-            (body.streams.length > 0 ? body.streams.length : '') +
-            '\n---\n' +
-            outputs.join('\n---\n'));
-    }
 
     require('https').get({
         hostname: urlHost,

--- a/Web/Twitch/livestreamer-now-playing.5m.js
+++ b/Web/Twitch/livestreamer-now-playing.5m.js
@@ -26,6 +26,13 @@ function readAccessToken() {
     } catch (e) {}
 }
 
+function outputForStream(stream) {
+    var channel = stream.channel;
+    var url = channel.url.replace('http://',    '');
+    return  [channel.display_name, ' | size=12 terminal=false bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('') +
+            ['[', stream.viewers, '] ', channel.status, '| size=12 alternate=true length=30 bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('');
+}
+
 function handleResponse(body) {
     var streamByGame = {};
     body.streams.forEach(function(stream) {
@@ -38,13 +45,8 @@ function handleResponse(body) {
 
     var outputs = [];
 
-    for (game in streamByGame) {
-        outputs.push(['', game, '| size=10 \n', streamByGame[game].map(function(stream) {
-            var channel = stream.channel;
-            var url = channel.url.replace('http://',    '');
-            return  [channel.display_name, ' | size=12 terminal=false bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('') +
-                    ['[', stream.viewers, '] ', channel.status, '| size=12 alternate=true length=30 bash=' + LIVESTREAMER_PATH + ' param1=', url, '\n'].join('');
-        }).join('')].join(''));
+    for (var game in streamByGame) {
+        outputs.push(['', game, '| size=10 \n', streamByGame[game].map(outputForStream).join('')].join(''));
     }
 
     console.log(


### PR DESCRIPTION
New plugin, based on code stolen with love from the [existing Twitch plugin](https://github.com/matryer/bitbar-plugins/blob/master/Web/Twitch/play-with-livestreamer.5m.js). 

The existing plugin shows the top N games for a configured game (eg Dota). This plugin shows the currently live streamers that you follow, which game they are playing, with alt-text showing watch count and the streamers title:
![image](https://cloud.githubusercontent.com/assets/583851/14369426/e16c4c6e-fd1c-11e5-864f-ced59c7e86d2.png)
![image](https://cloud.githubusercontent.com/assets/583851/14369461/23f6b416-fd1d-11e5-8353-1c28c9e0cab1.png)

Effectively being analogous to visiting https://twitch.tv/directory/following

It uses your auth key setup with livestreamer. If you haven't already set this up there is a link that runs the standard livestreamer auth setup process (twitch oauth page -> livestreamer page with instructions on where to paste your new key):
![image](https://cloud.githubusercontent.com/assets/583851/14369585/42f7365a-fd1e-11e5-87e4-457c0c186847.png)