### PR TITLE
Small fix for redmine plugin.

### DIFF
--- a/Dev/Redmine/redmine-show-my-task.1m.rb
+++ b/Dev/Redmine/redmine-show-my-task.1m.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/env ruby
 # coding: utf-8
 
 # <bitbar.title>Redmine Show My Task</bitbar.title>


### PR DESCRIPTION
The advantage of #!/usr/bin/env ruby is that it will use whatever ruby executable appears first in the user's $PATH.