### PR TITLE
Stackoverflow - handle no internet connection

### DIFF
--- a/Web/StackOverflow/reputationizer.5m.sh
+++ b/Web/StackOverflow/reputationizer.5m.sh
@@ -27,7 +27,9 @@ fi
 # get reputation from api
 NEWREP=$(curl -s --compressed "$URI" | egrep -o '"reputation":*([0-9])+' | sed 's/"reputation"://')
 
-if [ "$NEWREP" -gt "$OLDREP" ] ; then
+if [ -z "$OLDREP" ] || [ -z "$NEWREP" ] ; then
+  echo ❓
+elif [ "$NEWREP" -gt "$OLDREP" ] ; then
   echo 👍
 elif [ "$OLDREP" -gt "$NEWREP" ] ; then
   echo 👎


### PR DESCRIPTION
If there is no internet when the script runs the `greater than` comparison fails. This change handles more gracefully this situation by printing a question mark.