### PR TITLE
updated subreddit links to specify a user agent.

### DIFF
--- a/Web/Reddit/subreddit_links.rb
+++ b/Web/Reddit/subreddit_links.rb
@@ -37,7 +37,7 @@ def to_json(subreddit, type)
   @http.add_field('User-Agent', USER_AGENT)
  
   res = Net::HTTP.start(uri.host, DEFAULT_PORT) do |http| 
-    response = http.request(@http)
+    http.request(@http)
   end
  
   data = JSON.parse(res.body)

--- a/Web/Reddit/subreddit_links.rb
+++ b/Web/Reddit/subreddit_links.rb
@@ -1,5 +1,11 @@
 #!/usr/bin/env ruby
 
+# <bitbar.title>Subreddit Links</bitbar.title>
+# <bitbar.author>Joe Canero</bitbar.author>
+# <bitbar.author.github>caneroj1</bitbar.author.github>
+# <bitbar.image>https://i.imgur.com/3ZDUdNH.png</bitbar.image>
+# <bitbar.version>1.0</bitbar.version>
+
 require 'net/http'
 require 'json'
 
@@ -18,10 +24,23 @@ SUBREDDITS = [
   ["r/AskReddit", "/top"],
 ]
 
+# Feel free to make the user agent your username
+# It looks like reddit just requires the user agent to be
+# something unique and not generic.
+USER_AGENT = "bitbar-user-agent"
 REDDIT = "https://www.reddit.com/"
+DEFAULT_PORT = 80
+
 def to_json(subreddit, type)
-  url = "#{REDDIT}#{subreddit}#{type}.json"
-  data = JSON.parse(Net::HTTP.get(URI(url)))
+  uri = URI.parse("#{REDDIT}#{subreddit}#{type}.json")
+  @http = Net::HTTP::Get.new(uri)
+  @http.add_field('User-Agent', USER_AGENT)
+ 
+  res = Net::HTTP.start(uri.host, DEFAULT_PORT) do |http| 
+    response = http.request(@http)
+  end
+ 
+  data = JSON.parse(res.body)
   data["subreddit_name"] = (subreddit.eql?("") ? "Front Page" : subreddit) + type
   data
 end


### PR DESCRIPTION
This pull request addresses issue #416, where the request to get subreddit links was receiving an HTTP 429 Error. 

That error was being received because reddit was rate-limiting our request when it was coming in from the default user-agent Ruby uses in the Net/HTTP library. We now specify a generic bitbar user-agent when we send the request. That user-agent can also be changed on a per user basis, so people can add a more detailed user-agent if they want.
