### PR TITLE
Filter out extra annotations from tools such as bugwarrior

### DIFF
--- a/Lifestyle/taskwarrior.4m.py
+++ b/Lifestyle/taskwarrior.4m.py
@@ -65,7 +65,7 @@ def print_output(cmd,color,head,print_content=True,command='',ignore_id_list=[],
         # When looking for 'active' or 'next' tasks, we want to look only at
         # lines that start with a digit or a -. Other line are likely extra
         # data like annotations from bugwarrior sync
-        content_id = output_line.split()[0].strip()
+        content_id = output_line.split()[0]
         if not content_id.isdigit() and content_id not in ['--', '-', 'ID']:
             continue
         content_lines.append(output_line)

--- a/Lifestyle/taskwarrior.4m.py
+++ b/Lifestyle/taskwarrior.4m.py
@@ -60,8 +60,15 @@ def print_output(cmd,color,head,print_content=True,command='',ignore_id_list=[],
 
     for output_line in output_lines:
         output_line = output_line.strip()
-        if len(output_line) > 0:
-            content_lines.append(output_line)
+        if not output_line:
+            continue
+        # When looking for 'active' or 'next' tasks, we want to look only at
+        # lines that start with a digit or a -. Other line are likely extra
+        # data like annotations from bugwarrior sync
+        content_id = output_line.split()[0].strip()
+        if not content_id.isdigit() and content_id not in ['--', '-', 'ID']:
+            continue
+        content_lines.append(output_line)
 
     content_count = len(content_lines[2:-1])
 


### PR DESCRIPTION
Fixes #421

This should go through and parse out the extra empty lines and only look
for lines that start with a digit (task ID) or one of the markers used
to print up the UI

Will need to have @chrisidefix check it since he is the original author of the plugin.
Thanks again for the tip and for your patience in my delayed responses :) 