### PR TITLE
[Dev/Homebrew/brew-services] Fix All menu

### DIFF
--- a/Dev/Homebrew/brew-services.10m.rb
+++ b/Dev/Homebrew/brew-services.10m.rb
@@ -94,7 +94,7 @@ started = services[:started]
 menus = services[:menus].join("\n")
 all = ""
 if total > 0
-"""
+  all = """
 All
 --Start #{plural(total - started)} | #{service("start", "--all")}
 --Stop #{plural(started)} | #{service("stop", "--all")}


### PR DESCRIPTION
Forgot to actually use the *All* menu when fixing the Rubocop warnings.