### PR TITLE
Remove trailing newline when copying IP address to clipboard

### DIFF
--- a/Network/external-ip.1h.sh
+++ b/Network/external-ip.1h.sh
@@ -9,7 +9,7 @@ EXTERNAL_IP=$(dig +short myip.opendns.com @resolver1.opendns.com)
 
 if [ "$1" = "copy" ]; then
   # Copy the IP to clipboard
-  echo "$EXTERNAL_IP" | pbcopy
+  echo -n "$EXTERNAL_IP" | pbcopy
 fi
 
 echo "$EXTERNAL_IP"


### PR DESCRIPTION
In Network/external_ip.1h.sh
Do not add a trailing newline when copying an external IP address to the clipboard.