### PR TITLE
MAS support

### DIFF
--- a/Dev/Homebrew/package_manager.7h.py
+++ b/Dev/Homebrew/package_manager.7h.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # <bitbar.title>Package Manager</bitbar.title>
-# <bitbar.version>v1.3</bitbar.version>
+# <bitbar.version>v1.5</bitbar.version>
 # <bitbar.author>Kevin Deldycke</bitbar.author>
 # <bitbar.author.github>kdeldycke</bitbar.author.github>
 # <bitbar.desc>List package updates available from Homebrew, Cask, Python's pip2 and pip3, Node's npm, Atom's apm and Rebuy's gem. Allows individual or full upgrades (if available).</bitbar.desc>
@@ -12,6 +12,17 @@
 """
 Changelog
 =========
+
+1.5 (2016-07-25)
+----------------
+* Add support for [mas](https://github.com/argon/mas)
+* Don't show all stderr as err (check return code for error state)
+
+1.4 (2016-07-10)
+----------------
+* Don't attempt to parse empty lines
+* Check for linked npm packages
+* Support System or Homebrew Ruby Gems (with proper sudo setup)
 
 1.3 (2016-07-09)
 ----------------

--- a/Dev/Homebrew/package_manager.7h.py
+++ b/Dev/Homebrew/package_manager.7h.py
@@ -505,8 +505,10 @@ class MAS(PackageManager):
         if not output:
             return
 
-        regexp = re.compile(r'(\d+) (.*) \(\S+\)$')
+        regexp = re.compile(r'(\d+) (.*) \((\S+)\)$')
         for application in output.split('\n'):
+            if not application:
+                continue
             _id, name, version = regexp.match(application).groups()
             self.map[name] = _id
             self.updates.append({

--- a/Dev/Homebrew/package_manager.7h.py
+++ b/Dev/Homebrew/package_manager.7h.py
@@ -83,8 +83,9 @@ class PackageManager(object):
         """ Run a shell command, return the output and keep error message.
         """
         self.error = None
-        output, error = Popen(args, stdout=PIPE, stderr=PIPE).communicate()
-        if error:
+        process = Popen(args, stdout=PIPE, stderr=PIPE)
+        output, error = process.communicate()
+        if process.returncode != 0 and error:
             self.error = error
         return output
 
@@ -153,6 +154,8 @@ class Homebrew(PackageManager):
 
         # List available updates.
         output = self.run(self.cli, 'outdated', '--json=v1')
+        if not output:
+            return
 
         for pkg_info in json.loads(output):
             self.updates.append({
@@ -550,7 +553,7 @@ def print_menu():
         print("---")
 
         if manager.error:
-            for line in manager.error.split("\n"):
+            for line in manager.error.strip().split("\n"):
                 print("{} | color=red".format(line))
 
         print("{} {} package{}".format(


### PR DESCRIPTION
FAO: @kdeldycke

[mas](https://github.com/argon/mas) allows you to manipulate Mac AppStore applications from the command line.  In it's current version it does not display information on the installed version of the application.  Watch argon/mas#26 for potential fixes.  For now, `installed_version` is reported as `''` which works pretty well:

![screenshot](https://cloud.githubusercontent.com/assets/210250/17111037/fd4b8cfc-525c-11e6-99d9-699f16347334.png)

Also, did some cleanup on how `stderr` is handled and displayed.  Much cleaner now w/ less whitespace and doesn't display warnings as errors. (`process.returncode` check for truthiness.)
