### PR TITLE
Add /usr/local/bin to path if it is missing.

### DIFF
--- a/Dev/package_manager.7h.py
+++ b/Dev/package_manager.7h.py
@@ -88,6 +88,10 @@ class PackageManager(object):
 
     cli = None
 
+    path_list = os.environ.get('PATH','').split(os.pathsep)
+    if not '/usr/local/bin' in path_list:
+        os.environ['PATH'] += ':/usr/local/bin'
+
     def __init__(self):
         # List all available updates and their versions.
         self.updates = []

--- a/Dev/package_manager.7h.py
+++ b/Dev/package_manager.7h.py
@@ -88,9 +88,26 @@ class PackageManager(object):
 
     cli = None
 
-    path_list = os.environ.get('PATH','').split(os.pathsep)
-    if not '/usr/local/bin' in path_list:
-        os.environ['PATH'] += ':/usr/local/bin'
+    # OS X does not put /usr/local/bin or /opt/local/bin in
+    # the PATH for GUI apps. For some package managers this
+    # is a problem. If you get an error similar to
+    #
+    # "env: node: No such file or directory
+    #
+    # it is most likely that something is missing from the
+    # path. However Homebrew and Macports are using different pathes.
+    #
+    # For Homebrew uncomment next line:
+    #extra_path='/usr/local/bin'
+    # For MacPorts uncomment next line
+    #extra_path='/opt/local/bin'
+    # For both Homebrew and MacPorts uncomment the following lines:
+    #path_list = os.environ.get('PATH','').split(os.pathsep)
+    #if not extra_path in path_list:
+    #    os.environ['PATH'] += ":" + extra_path
+
+    print(os.environ['PATH'])
+    exit(0)
 
     def __init__(self):
         # List all available updates and their versions.

--- a/Dev/package_manager.7h.py
+++ b/Dev/package_manager.7h.py
@@ -106,9 +106,6 @@ class PackageManager(object):
     #if not extra_path in path_list:
     #    os.environ['PATH'] += ":" + extra_path
 
-    print(os.environ['PATH'])
-    exit(0)
-
     def __init__(self):
         # List all available updates and their versions.
         self.updates = []


### PR DESCRIPTION
GUI apps on OS X usually don’t have /usr/local/bin in their PATH by default, so add it if it is missing. Needed for at least npm, which does a /usr/bin/env node to find out where node is installed. 

See for instance the Homebrew FAQ, https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/FAQ.md#my-mac-apps-dont-find-usrlocalbin-utilities