### PR TITLE
Change ip-flag plugin from ipinfo.io to ip-api.com due to higher rate limit

### DIFF
--- a/Network/ip-flag.2m.rb
+++ b/Network/ip-flag.2m.rb
@@ -8,9 +8,11 @@
 # <bitbar.dependencies>OS X 10.11</bitbar.dependencies>
 
 require 'open-uri'
+require 'json'
 
 begin
-  country_code = open('http://ipinfo.io/country').string.chomp.split ''
+  cc = JSON.load(open('http://ip-api.com/json'))
+  country_code = cc['countryCode'].chomp.split ''
   c1, c2 = *country_code.map { |c| (c.ord + 0x65).chr.force_encoding 'UTF-8' }
   puts "\xF0\x9F\x87#{c1}\xF0\x9F\x87#{c2}"
 rescue StandardError => err


### PR DESCRIPTION
While I do prefer ipinfo.io, I've updated `Network/ip-flag.2m.rb` to instead use ip-api.com due to a higher rate limit.

ipinfo.io: 1000 reqs/day vs ip-api.com: 150 reqs/min

http://ipinfo.io/developers#rate-limits
http://ip-api.com/docs/api:json#usage_limits