### PR TITLE
Round up number if it is a decimal

### DIFF
--- a/Network/ping.10s.sh
+++ b/Network/ping.10s.sh
@@ -36,7 +36,7 @@ PING_TIMES=
 
 while [ $SITE_INDEX -lt ${#SITES[@]} ]; do
     NEXT_SITE="${SITES[$SITE_INDEX]}"
-    NEXT_PING_TIME=$(ping -c 2 -n -q "$NEXT_SITE" 2>/dev/null | awk -F '/' 'END {printf "%d\n", $5}')
+    NEXT_PING_TIME=$(ping -c 2 -n -q "$NEXT_SITE" 2>/dev/null | awk -F '/' 'END {printf "%.0f\n", $5}')
     if [ "$NEXT_PING_TIME" -eq 0 ]; then
         NEXT_PING_TIME=$MAX_PING
     fi


### PR DESCRIPTION
If you have sites with sub 1 ms ping, it would be seen as down.

It still says zero if there is no contact.

This is my ping

```
$ ping google.dk
PING google.dk (212.98.120.16): 56 data bytes
64 bytes from 212.98.120.16: icmp_seq=0 ttl=59 time=0.956 ms
64 bytes from 212.98.120.16: icmp_seq=1 ttl=59 time=0.918 ms
64 bytes from 212.98.120.16: icmp_seq=2 ttl=59 time=0.934 ms
^C
--- google.dk ping statistics ---
3 packets transmitted, 3 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 0.918/0.936/0.956/0.016 ms
```