### PR TITLE
Simplify unixtime.5s.sh

### DIFF
--- a/Time/unixtime.5s.sh
+++ b/Time/unixtime.5s.sh
@@ -7,4 +7,4 @@
 # <bitbar.desc>Displays unix time.</bitbar.desc>
 # <bitbar.image>http://i.imgur.com/h2cyuYu.png</bitbar.image>
 
-date -j -f "%a %b %d %T %Z %Y" "$(date)" "+%s"
+date +%s


### PR DESCRIPTION
Apparently the date was called twice:
1. output date in default format
2. parse default format and covert to +%s

This commit avoids the parsing step.
