### PR TITLE
Modified to support SSL

### DIFF
--- a/Web/Reddit/subreddit_links.rb
+++ b/Web/Reddit/subreddit_links.rb
@@ -29,14 +29,14 @@ SUBREDDITS = [
 # something unique and not generic.
 USER_AGENT = "bitbar-user-agent"
 REDDIT = "https://www.reddit.com/"
-DEFAULT_PORT = 80
+DEFAULT_PORT = 443
 
 def to_json(subreddit, type)
   uri = URI.parse("#{REDDIT}#{subreddit}#{type}.json")
   @http = Net::HTTP::Get.new(uri)
   @http.add_field('User-Agent', USER_AGENT)
  
-  res = Net::HTTP.start(uri.host, DEFAULT_PORT) do |http| 
+  res = Net::HTTP.start(uri.host, DEFAULT_PORT, :use_ssl => true) do |http| 
     http.request(@http)
   end
  


### PR DESCRIPTION
Was getting the following error:
"A JSON text must at least contain two octets!
Content is currently unavailable. Please try resetting."

Modifying the default port and adding ":use_ssl => true" to the Net::HTTP.start block resolved this issue for me.