### PR TITLE
Remove unnecessary docker ps

### DIFF
--- a/Dev/Docker/docker-status.1m.sh
+++ b/Dev/Docker/docker-status.1m.sh
@@ -39,8 +39,7 @@ function containers() {
 
 DOCKER_MACHINES="$(docker-machine ls -q)"
 DLITE="$(which dlite)"
-CONTAINERS="$(docker ps -a --format "{{.Names}} ({{.Image}})|{{.ID}}|{{.Status}}")"
-if test -z "$DOCKER_MACHINES" && test -z "$DLITE" && test -z "$CONTAINERS"; then
+if test -z "$DOCKER_MACHINES" && test -z "$DLITE"; then
   echo "No docker machine or dlite found"
   exit 0
 fi


### PR DESCRIPTION
If docker-machine env not set by default it writes "Cannot to connect to docker host" message. On the other hand at this point there is no need to check running containers.