### PR TITLE
plugins-weather: switch location lookup to HTTPS

### DIFF
--- a/Weather/ForecastIO/weather.15m.py
+++ b/Weather/ForecastIO/weather.15m.py
@@ -19,7 +19,7 @@ units = '' # set to si for metric, leave blank for imperial
 
 def auto_loc_lookup():
   try:
-    location = urllib2.urlopen('http://ipinfo.io/json')
+    location = urllib2.urlopen('https://ipinfo.io/json')
     return json.load(location)
   except urllib2.URLError:
     return False


### PR DESCRIPTION
The location lookup should really be HTTPS. Doesn't look like the country lookup supports HTTPS.