### PR TITLE
Upgrade Meta Package Manager plugin to v2.2.0.

### DIFF
--- a/Dev/MetaPackageManager/meta_package_manager.7h.py
+++ b/Dev/MetaPackageManager/meta_package_manager.7h.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # <bitbar.title>Meta Package Manager</bitbar.title>
-# <bitbar.version>v2.1.1</bitbar.version>
+# <bitbar.version>v2.2.0</bitbar.version>
 # <bitbar.author>Kevin Deldycke</bitbar.author>
 # <bitbar.author.github>kdeldycke</bitbar.author.github>
 # <bitbar.desc>List outdated packages and manage upgrades.</bitbar.desc>
@@ -24,6 +24,12 @@ from operator import itemgetter
 from subprocess import PIPE, Popen
 
 PY2 = sys.version_info[0] == 2
+
+
+# Set to ``False`` to replace the default flat layout with an alternative
+# structure where all upgrade actions are put into submenus, one for each
+# manager.
+FLAT_LAYOUT = True
 
 
 def fix_environment():
@@ -79,12 +85,34 @@ def print_error_header():
     echo("---")
 
 
-def print_error(message):
-    """ Print a formatted error line by line, in red. """
+def print_error(message, submenu=""):
+    """ Print a formatted error line by line.
+
+    A red, fixed-width font is used to preserve traceback and exception layout.
+    """
     for line in message.strip().split("\n"):
         echo(
-            "{} | color=red font=Menlo size=10 trim=false "
-            "emojize=false".format(line))
+            "{}{} | color=red font=Menlo size=12 trim=false emojize=false"
+            "".format(submenu, line))
+
+
+def print_package_items(packages, submenu=""):
+    """ Print a menu entry for each outdated packages available for upgrade.
+    """
+    for pkg_info in packages:
+        echo(
+            "{}{name} {installed_version} → {latest_version} | {upgrade_cli}"
+            " terminal=false refresh=true emojize=false".format(
+                submenu, **pkg_info))
+
+
+def print_upgrade_all_item(manager, submenu=""):
+    """ Print the menu entry to upgrade all outdated package of a manager. """
+    if manager.get('upgrade_all_cli'):
+        if not FLAT_LAYOUT:
+            echo("-----")
+        echo("{}Upgrade all | {} terminal=false refresh=true".format(
+            submenu, manager['upgrade_all_cli']))
 
 
 def print_menu():
@@ -94,6 +122,8 @@ def print_menu():
     """
     # Search for generic mpm CLI on system.
     code, _, error = run('mpm')
+    # mpm CLI hasn't been found on the system. Propose to the user to install
+    # or upgrade it.
     if code or error:
         print_error_header()
         print_error(error)
@@ -110,6 +140,7 @@ def print_menu():
     _, output, error = run(
         'mpm', '--output-format', 'json', 'outdated', '--cli-format', 'bitbar')
 
+    # Bail-out immediately on errors related to mpm self-execution.
     if error:
         print_error_header()
         print_error(error)
@@ -120,32 +151,55 @@ def print_menu():
 
     # Print menu bar icon with number of available upgrades.
     total_outdated = sum([len(m['packages']) for m in managers])
-    total_errors = len([True for m in managers if m['error']])
+    total_errors = len([True for m in managers if m.get('error', None)])
     echo("↑{}{} | dropdown=false".format(
         total_outdated,
         " ⚠️{}".format(total_errors) if total_errors else ""))
 
     # Print a full detailed section for each manager.
-    for manager in managers:
+    submenu = "--" if not FLAT_LAYOUT else ""
+
+    if not FLAT_LAYOUT:
+        # Compute maximal manager's name length.
+        label_max_length = max([len(m['name']) for m in managers])
+        max_outdated = max([len(m['packages']) for m in managers])
+
+    if not FLAT_LAYOUT:
         echo("---")
 
-        if manager['error']:
-            print_error(manager['error'])
+    for manager in managers:
+        if FLAT_LAYOUT:
+            echo("---")
 
-        echo("{} outdated {} package{} | emojize=false".format(
-            len(manager['packages']),
-            manager['name'],
-            's' if len(manager['packages']) != 1 else ''))
+        package_label = "package{}".format(
+            's' if len(manager['packages']) != 1 else '')
 
-        if manager.get('upgrade_all_cli'):
-            echo("Upgrade all | {} terminal=false refresh=true".format(
-                manager['upgrade_all_cli']))
+        if FLAT_LAYOUT:
+            echo("{0} outdated {1} {2} | emojize=false".format(
+                len(manager['packages']),
+                manager['name'],
+                package_label))
 
-        for pkg_info in manager['packages']:
+        else:
+            # Non-flat layout use a compact table-like rendering of manager
+            # summary.
             echo(
-                "{name} {installed_version} → {latest_version} | {upgrade_cli}"
-                " terminal=false refresh=true emojize=false".format(
-                    **pkg_info))
+                "{0:<{max_length}} {1:>{max_outdated}} {2:<8} {3} | "
+                "font=Menlo size=12 emojize=false".format(
+                    manager['name'] + ':',
+                    len(manager['packages']),
+                    package_label,
+                    "⚠️" if manager.get('error', None) else '',
+                    max_length=label_max_length + 1,
+                    max_outdated=len(str(max_outdated))))
+
+        print_package_items(manager['packages'], submenu)
+
+        print_upgrade_all_item(manager, submenu)
+
+        if manager.get('error', None):
+            echo("---" if FLAT_LAYOUT else "-----")
+            print_error(manager['error'], submenu)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This version adds a new alternative table-like rendering, with all packages placed in submenus, one per package manager. This alternative version is not active by default.