### PR TITLE
fix thruk plugin

### DIFF
--- a/Dev/Nagios/thruk.py
+++ b/Dev/Nagios/thruk.py
@@ -20,7 +20,8 @@ ONLY_NEW = False
 checks = {
     'hosts': [],
     'hostgroups': [],
-    'servicegroups': []
+    'servicegroups': [],
+    'services': []
 }
 
 # STOP EDITING HERE!


### PR DESCRIPTION
Without this there is this error : 
➜  bitbar ./thruk.py 
Traceback (most recent call last):
  File "./thruk.py", line 56, in <module>
    if not checks['hosts'] and not checks['hostgroups'] and not checks['services'] and not checks['servicegroups']:
KeyError: 'services'
