### PR TITLE
handle when iTunes running but not responsive

### DIFF
--- a/Music/itunes.10s.sh
+++ b/Music/itunes.10s.sh
@@ -64,7 +64,23 @@ else
   COLOR3="#999999"
 fi
 
-state=$(osascript -e 'tell application "iTunes" to player state as string');
+state=$(osascript -e '
+try 
+  tell application "iTunes"
+    with timeout 3 seconds
+      player state as string
+    end timeout
+  end tell
+on error errText
+  "not available"
+end try  
+');
+if [ "$state" = "not available" ]; then
+  echo "♫ | size=12"
+  echo "---"
+  echo "iTunes is not available"
+  exit
+fi
 
 track=$(osascript -e'
 try


### PR DESCRIPTION
After a reboot I have iTunes set to start automatically and hidden. It does so in some half-open state apparently that causes all the AppleScript commands to hang and eventually timeout.
The change below captures this quickly and handles in a more elegant manner - preferred over seeing an error in the bitbar display
Thought others might find it useful as well