### PR TITLE
Network/DNSSwitcher: Add Google IPv6 DNS servers

### DIFF
--- a/Network/dnsswitcher.1d.sh
+++ b/Network/dnsswitcher.1d.sh
@@ -19,7 +19,10 @@ network_service="Wi-FI"
 # add or remove list of DNS options below, don't forget to make it enabled. see below
 # shellcheck disable=2034
 google="8.8.8.8
-        8.8.4.4"
+        8.8.4.4
+        
+        2001:4860:4860::8888
+        2001:4860:4860::8844"
 
 # shellcheck disable=2034
 level3="209.244.0.3


### PR DESCRIPTION
Documented at https://developers.google.com/speed/public-dns/docs/using#google_public_dns_ip_addresses