### PR TITLE
Modified gmail-checker-improved to include the email count in the bar

### DIFF
--- a/Email/gmail-checker-improved.1m.pl
+++ b/Email/gmail-checker-improved.1m.pl
@@ -41,7 +41,7 @@ if ($content->status_line eq '200 OK') {
 	my $ref = XMLin($content->content, ForceArray=>'entry');
 
 	if ($ref->{fullcount}->[0] > 0) {
-		$output .= "📬\n";
+		$output .= "📬 ".$ref->{fullcount}->[0]."\n";
 		$output .= "---\n";
 		
 		if ($ref->{fullcount}->[0] == 1) {


### PR DESCRIPTION
Gmail checker has the nice numeral indicator. However, that is bash and doesn't have any features. So I added the numeric counter next to the icon. It's personal preference, but I think it adds to the functionality. 