### PR TITLE
Added numerical counter for Pi-Hole tracjer

### DIFF
--- a/Email/gmail-checker-improved.1m.pl
+++ b/Email/gmail-checker-improved.1m.pl
@@ -41,7 +41,7 @@ if ($content->status_line eq '200 OK') {
 	my $ref = XMLin($content->content, ForceArray=>'entry');
 
 	if ($ref->{fullcount}->[0] > 0) {
-		$output .= "📬\n";
+		$output .= "📬 ".$ref->{fullcount}->[0]."\n";
 		$output .= "---\n";
 		
 		if ($ref->{fullcount}->[0] == 1) {

--- a/Network/pi-hole.1m.py
+++ b/Network/pi-hole.1m.py
@@ -19,11 +19,20 @@ import json
 # Change to Your Pi-Hole Admin Console URL
 pihole = "http://192.168.0.101/admin/"
 
+def format(number):
+  number = int(number)
+  if number > 1000000:
+    return str(number/1000000) + 'M'
+  elif number > 1000:
+    return str(number/1000) + 'k'
+  else:
+    return number
+
 try:
     url = pihole + "api.php"
     result = urllib2.urlopen(url, timeout = 5).read()
     json = json.loads(result)
-    print "🌍"
+    print "🌍 {0}".format(format(json['ads_blocked_today']))
     print "---"
     print "Ads blocked:"
     print json['ads_blocked_today'] + "| href=" + pihole


### PR DESCRIPTION
The Pi-hole tracker now shows how many ads are blocked on the bar itself (next to the world icon.) Also uses metric truncation (k and M.)

In 2017, the Pie icon will be added to the emoji list. We should change the icon to that if it's not terrible. 

PS: I tried to keep gmail-checker's changes out of this commit. Apparently without success :\. Sorry.