### PR TITLE
Add plugin to delete Visual Studio Code temporary files

### DIFF
--- a/System/deleteVSCodeTemp.sh
+++ b/System/deleteVSCodeTemp.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# <bitbar.title>Delete VSCode Temp Files</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author.github>AlexPoulsen</bitbar.author.github>
+# <bitbar.author>AlexPoulsen</bitbar.author>
+# <bitbar.desc>Deletes Visual Studio Code Temporary Files</bitbar.desc>
+
+if [ "$1" = 'clean' ]; then
+  sudo find /Users/macbookpro/Documents/VSCode\ Projects/ -name "temp*" -d -ok rm {} \;
+  read -p "Files are about to be deleted, continue? [Y/n] " check
+  if [[ ( $check == "Y" ) || ( $check == "y" ) ]]; then
+    sudo find /Users/macbookpro/Documents/VSCode\ Projects/ -name "temp*" -d -exec rm {} \;
+    echo "Deleted from default directory"
+  else
+    echo "Files not deleted"
+  fi
+fi
+
+echo "🗑"
+echo '---'
+echo "Clean Temp Files | bash='$0' param1=clean terminal=true"


### PR DESCRIPTION
Visual Studio Code leaves a lot of temporary files around after running code and creates new ones anytime code is run, even if the old temp files are still there and the code is untouched. This deletes all files in the folder it is pointed to that start with 'temp'.