### PR TITLE
Added Persian date plugin

### DIFF
--- a/Time/persiandate.1m.sh
+++ b/Time/persiandate.1m.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# <bitbar.title>Persian Date</bitbar.title>
+# <bitbar.version>v0.1</bitbar.version>
+# <bitbar.author>Ilia Vakili</bitbar.author>
+# <bitbar.author.github>theReticent</bitbar.author.github>
+# <bitbar.desc>Shows Persian date</bitbar.desc>
+# <bitbar.image></bitbar.image>
+# <bitbar.dependencies>jcal</bitbar.dependencies>
+
+# To fix the "command not found" caused by installing jcal using brew
+PATH=/usr/local/bin:$PATH
+
+jdate "+%W"
+echo "---"
+jdate "+%G %d %V %Y"


### PR DESCRIPTION
[Persian calendar](https://en.wikipedia.org/wiki/Iranian_calendars#Modern_calendar:_Solar_Hijri_.28SH.29) is not natively supported by Mac OS. I added a simple plugin to show the Persian date using BitBar. The plugin uses [jcal](http://brewformulas.org/jcal) which can be installed using brew.

<img width="346" alt="capture d ecran 2017-02-25 a 21 03 46" src="https://cloud.githubusercontent.com/assets/10159793/23333297/ae94e41e-fb9e-11e6-9551-4b1751fa0041.png">
