### PR TITLE
Restrict grep pattern for matching service

### DIFF
--- a/System/launch-agents.10s.sh
+++ b/System/launch-agents.10s.sh
@@ -43,11 +43,11 @@ then "$launchctl" unload "$2"
 fi
 
 function service_pid {
-    "$launchctl" list | grep "$1" | sed -E 's/^([-0-9]+).*([0-9]+).*/\1/'
+    "$launchctl" list | grep "$1\$" | sed -E 's/^([-0-9]+).*([0-9]+).*/\1/'
 }
 
 function service_status {
-    "$launchctl" list | grep "$1" | sed -E 's/^([-0-9]+).*([0-9]+).*/\2/'
+    "$launchctl" list | grep "$1\$" | sed -E 's/^([-0-9]+).*([0-9]+).*/\2/'
 }
 
 function service_property {


### PR DESCRIPTION
Some launchctl services might have names that are substring of other services and the existing grep command thus returns a multiline result.