### PR TITLE
Fix pi-hole script

### DIFF
--- a/Network/pi-hole.1m.py
+++ b/Network/pi-hole.1m.py
@@ -26,11 +26,13 @@ try:
     print "🌍"
     print "---"
     print "Ads blocked:"
-    print json['ads_blocked_today'] + "| href=" + pihole
+    print json['ads_blocked_today'] , "| href=" , pihole
     print "DNS queries:"
-    print json['dns_queries_today'] + "| href=" + pihole
+    print json['dns_queries_today'] , "| href=" , pihole
+    print "% of ad traffic today:"
+    print json['ads_percentage_today'] , "| href=" , pihole
     print "Domain list size:"
-    print json['domains_being_blocked'] + "| href=" + pihole
+    print json['domains_being_blocked'] , "| href=" , pihole
     print "---"
     
 except:


### PR DESCRIPTION
Was getting error with newest version of pi-hole:

```
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```
This seems to fix