### PR TITLE
Handle Taskwarrior task list alignment issues with multi-digit IDs

### DIFF
--- a/Lifestyle/taskwarrior.4m.py
+++ b/Lifestyle/taskwarrior.4m.py
@@ -115,11 +115,12 @@ def print_output(
         print '---'
 
     for content_line in content_lines[2:-1]:
-        content_id = content_line.split()[0]
-
+        content_re = re.match('^\[\s*(.+)\]\s+([0-9A-Fa-f]+)?', content_line)
+        content_id = content_re.group(1)
+        
         if content_id == '-':
             # should be the UUID in this case
-            content_id = content_line.split()[1]
+            content_id = content_re.group(2)
 
         if content_id in ignore_id_list:
             continue

--- a/Lifestyle/taskwarrior.4m.py
+++ b/Lifestyle/taskwarrior.4m.py
@@ -22,6 +22,7 @@
 #
 
 import os
+import re
 import subprocess
 from subprocess import Popen, PIPE
 
@@ -73,7 +74,7 @@ def print_output(
     content_lines = []
 
     for output_line in output_lines:
-        output_line = output_line.strip()
+        output_line = output_line.rstrip()
         if not output_line:
             continue
         # When looking for 'active' or 'next' tasks, we want to look only at
@@ -82,7 +83,8 @@ def print_output(
         content_id = output_line.split()[0]
         if not content_id.isdigit() and content_id not in ['--', '-', 'ID']:
             continue
-        content_lines.append(output_line)
+        line_groups = re.match('^(\s*\d+|\s*ID|\s*-+)(.*)', output_line)
+        content_lines.append('[{}]{}'.format(*line_groups.groups()))
 
     content_count = len(content_lines[2:-1])
 


### PR DESCRIPTION
Places square brackets around IDs, preserving right padding. A rstrip alone is not enough, as the padding gets mangled later within BitBar, before display.

Resolves  #780

Tested to work with an empty task list and with 1 and 2 digits task IDs

![alignment fix](https://cloud.githubusercontent.com/assets/195324/26711728/16c0da38-4795-11e7-9cd4-40a0b4aef806.png)

