### PR TITLE
rm -f "$tmp_dir/item-*.pb"  -->  rm -f "$tmp_dir"/item-*.pb

### DIFF
--- a/System/clipboard-history.3s.sh
+++ b/System/clipboard-history.3s.sh
@@ -27,7 +27,7 @@ fi
 
 # If user clicked clear, remove history items
 if [[ "$1" = "clear" ]]; then
-  rm -f "$tmp_dir/item-*.pb"
+  rm -f "$tmp_dir"/item-*.pb
   osascript -e "display notification \"Cleared clipboard history\" with title \"BitBar Clipboard History\"" &> /dev/null
   exit
 fi


### PR DESCRIPTION
changed parenthesis on the clear function so that "$tmp_dir" would expand to the actual directory.