### PR TITLE
New Plugin: chunkwm/skhd helper

### DIFF
--- a/Tools/chunkwm_skhd.1s.sh
+++ b/Tools/chunkwm_skhd.1s.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# <bitbar.title>chunkwm/skhd helper</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Shi Han NG</bitbar.author>
+# <bitbar.author.github>shihanng</bitbar.author.github>
+# <bitbar.desc>Plugin that displays desktop id and desktop mode of chunkwm.</bitbar.desc>
+# <bitbar.dependencies>brew,chunkwm,skhd</bitbar.dependencies>
+
+# Info about chunkwm, see: https://github.com/koekeishiya/chunkwm
+# For skhd, see: https://github.com/koekeishiya/skhd
+
+export PATH=/usr/local/bin:$PATH
+
+if [[ "$1" = "stop" ]]; then
+  brew services stop chunkwm
+  brew services stop skhd
+fi
+
+if [[ "$1" = "restart" ]]; then
+  brew services restart chunkwm
+  brew services restart skhd
+fi
+
+echo "$(chunkc tiling::query --desktop id):$(chunkc tiling::query --desktop mode) | length=5"
+echo "---"
+echo "Restart chunkwm & skhd | bash='$0' param1=restart terminal=false"
+echo "Stop chunkwm & skhd | bash='$0' param1=stop terminal=false"


### PR DESCRIPTION
Hi, I've been playing with:
- Windows manager for macOS: https://github.com/koekeishiya/chunkwm
- Hotkey daemon: https://github.com/koekeishiya/skhd

and made this bitbar-plugin to
- Show the display id and layout mode,
- Restart chunkwm & skhd services
- Stop chunkwm & skhd services

<img width="239" alt="screen shot 2017-12-15 at 15 15 41" src="https://user-images.githubusercontent.com/7593229/34030753-a176152e-e1b1-11e7-9cee-8d129f4bc9ed.png">

Feel free to merge this if you think it might be helpful for others. I am also happy to provide more info in necessary. Thanks