### PR TITLE
Added ISC condition monitor

### DIFF
--- a/Network/isccond.5m.sh
+++ b/Network/isccond.5m.sh
@@ -2,7 +2,7 @@
 
 # <bitbar.title>ISC Condition Monitor</bitbar.title>
 # <bitbar.version>v1.0</bitbar.version>
-# <bitbar.author></bitbar.author>
+# <bitbar.author>panzertime</bitbar.author>
 # <bitbar.author.github>panzertime</bitbar.author.github>
 # <bitbar.desc>Gets ISC's condition code and displays it</bitbar.desc>
 # <bitbar.image></bitbar.image>

--- a/Network/isccond.5m.sh
+++ b/Network/isccond.5m.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# <bitbar.title>ISC Condition Monitor</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author></bitbar.author>
+# <bitbar.author.github>panzertime</bitbar.author.github>
+# <bitbar.desc>Gets ISC's condition code and displays it</bitbar.desc>
+# <bitbar.image></bitbar.image>
+# <bitbar.dependencies></bitbar.dependencies>
+# <bitbar.abouturl>https://github.com/panzertime/bitbar-plugins</bitbar.abouturl>
+
+color=$(curl --silent -m 1 https://isc.sans.edu/infocon.txt | tr [a-z] [A-Z])
+echo "ISC Cond ${color} | color=${color}"

--- a/Network/isccond.5m.sh
+++ b/Network/isccond.5m.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# disabling a linter check which doesn't like unquoted tr
+# shellcheck disable=SC2060
+
 # <bitbar.title>ISC Condition Monitor</bitbar.title>
 # <bitbar.version>v1.0</bitbar.version>
 # <bitbar.author>panzertime</bitbar.author>


### PR DESCRIPTION
This plugin gets the current status code from SANS ISC ([more info](https://isc.sans.edu/infocon.html)) and displays the current status in the appropriate color.