### PR TITLE
Add "default" DNS to DNS Switcher

### DIFF
--- a/Network/dnsswitcher.1d.sh
+++ b/Network/dnsswitcher.1d.sh
@@ -20,7 +20,7 @@ network_service="Wi-FI"
 # shellcheck disable=2034
 google="8.8.8.8
         8.8.4.4
-        
+
         2001:4860:4860::8888
         2001:4860:4860::8844"
 
@@ -48,30 +48,40 @@ norton="199.85.126.10
         199.85.126.30
         199.85.127.30"
 
-enabled_dns_address=(google level3 opendns norton)
+# shellcheck disable=2034
+default="empty"
+
+enabled_dns_address=(google level3 opendns norton default)
 ########################
 
 
 selected_dns="Unknown"
+current_dns_output="$(networksetup -getdnsservers $network_service)"
 
-IFS=', ' read -r -a current_dns_address <<< "$(networksetup -getdnsservers $network_service | xargs)"
+if [[ $current_dns_output == There* ]] # For e.g. "There aren't any DNS Servers set on Wi-Fi."
+then
+    selected_dns="default"
+else
+    IFS=', ' read -r -a current_dns_address <<< $current_dns_output
 
-for dns_name in "${enabled_dns_address[@]}"
-do
-    for current_dns in "${current_dns_address[@]}"
+    for dns_name in "${enabled_dns_address[@]}"
     do
-    dns_option="$(eval echo \$"${dns_name}" | xargs)"
-        if [[ $dns_option == *"$current_dns"* ]]
-        then
-            selected_dns="$dns_name"
-        fi
+        for current_dns in "${current_dns_address[@]}"
+        do
+        dns_option="$(eval echo \$"${dns_name}" | xargs)"
+            if [[ $dns_option == *"$current_dns"* ]]
+            then
+                selected_dns="$dns_name"
+            fi
+        done
     done
-done
+fi
 
+
+### Bitbar Menu
 if [[ $selected_dns == "Unknown" ]]
 then
     echo "Unrecognized DNS"
-    networksetup -getdnsservers $network_service
 else
     echo "$selected_dns"
 fi
@@ -87,6 +97,5 @@ dns_address='$(eval "echo \${${dns_name[*]}}")'
 networksetup -setdnsservers $network_service \$(echo \$dns_address)
 EOF
   chmod 700 "$switcher"
-
-  echo "$dns_name | bash=$switcher | terminal=true | refresh=true"
+  echo "$dns_name | bash=$switcher | terminal=false | refresh=true"
 done

--- a/Network/dnsswitcher.1d.sh
+++ b/Network/dnsswitcher.1d.sh
@@ -62,7 +62,7 @@ if [[ $current_dns_output == There* ]] # For e.g. "There aren't any DNS Servers 
 then
     selected_dns="default"
 else
-    IFS=', ' read -r -a current_dns_address <<< $current_dns_output
+    IFS=', ' read -r -a current_dns_address <<< "$current_dns_output"
 
     for dns_name in "${enabled_dns_address[@]}"
     do


### PR DESCRIPTION
Adding a "default" DNS. (Unsetting the DNS and letting it become router-assigned)
Especially useful when you need to navigate to a transition page to use free wifi, for example.