### PR TITLE
Improve Spotify plugin

### DIFF
--- a/Music/spotify.10s.sh
+++ b/Music/spotify.10s.sh
@@ -3,24 +3,52 @@
 # Get current Spotify status with play/pause button
 #
 # by Jason Tokoph (jason@tokoph.net)
+#    Marcin Swieczkowski (scatman@bu.edu)
 #
-# Shows current track information from spotify
-# 10 second refresh might be a little too quick. Tweak to your liking.
+# Shows current track information for Spotify
 
 # metadata
 # <bitbar.title>Spotify Now Playing</bitbar.title>
 # <bitbar.version>v1.2</bitbar.version>
-# <bitbar.author>Jason Tokoph</bitbar.author>
+# <bitbar.author>Marcin S., Jason Tokoph</bitbar.author>
 # <bitbar.author.github>jtokoph</bitbar.author.github>
 # <bitbar.desc>Display currently playing Spotify song. Play/pause, skip forward, skip backward.</bitbar.desc>
 # <bitbar.image>http://i.imgur.com/y1SZwfq.png</bitbar.image>
 
+# Comment the following line to disable showing times.
+SHOW_TIME=1
+
+# By default we remove anything after " - ", as it usually is stuff like
+# "Remastered", "Single Version", or other garbage that Spotify likes to
+# include.
+#
+# You can comment out this line if you want the full track names.
+CLEAN_TRACK_NAMES=1
+
+# The length of a track/artist name after which to truncate.
+TRUNC_LEN=18
+# String used when replacing truncated text.
+TRUNC_SUFFIX="..."
+
+# Send a series of semicolon-delimited commands to Spotify
 function tellspotify() {
-  osascript -e "tell application \"Spotify\" to $1"
+  commands="$(echo "$1" | tr ";" "\\n")"
+
+  osascript -e "
+            tell application \"Spotify\"
+                $commands
+            end tell";
 }
+
+## Handle early-return cases
 
 if [ "$1" = 'launch' ]; then
   tellspotify 'activate'
+  exit
+fi
+
+if [ "$1" = 'lyrics' ]; then
+  osascript -e "do shell script \"open 'https://www.musixmatch.com/search/$track $artist'\""
   exit
 fi
 
@@ -32,18 +60,45 @@ if [ "$(osascript -e 'application "Spotify" is running')" = "false" ]; then
   exit
 fi
 
-case "$1" in
-  'playpause' | 'previous track' | 'next track')
+first="$(echo "$1" | head -n 1 | awk '{print $1;}')"
+case "$first" in
+  'playpause' | 'previous' | 'next' | 'set')
     tellspotify "$1"
     exit
 esac
 
+## Get Spotify info
+
 state=$(tellspotify 'player state as string');
 track=$(tellspotify 'name of current track as string');
 artist=$(tellspotify 'artist of current track as string');
-if [ "$1" = 'lyrics' ]; then
-  osascript -e "do shell script \"open 'https://www.musixmatch.com/search/$track $artist'\""
-  exit
+album=$(tellspotify 'album of current track as string');
+
+if [[ $SHOW_TIME ]]; then
+  position=$(osascript -e \
+                       "tell application \"Spotify\"
+                            set pos_sec to player position
+                            set time_min to (pos_sec / 60 div 1) as text
+                            set raw_sec to (pos_sec mod 60 div 1) as text
+                            if length of raw_sec is greater than 1 then
+                                set time_sec to raw_sec
+                            else
+                                set time_sec to \"0\" & raw_sec
+                            end if
+                            return time_min as text & \":\" & time_sec as text
+                        end tell");
+  duration=$(osascript -e \
+                       "tell application \"Spotify\"
+                            set total_sec to (duration of current track / 1000) as text
+                            set time_min to (total_sec / 60 div 1) as text
+                            set raw_sec to (total_sec mod 60 div 1) as text
+                            if length of raw_sec is greater than 1 then
+                                set time_sec to raw_sec
+                            else
+                                set time_sec to \"0\" & raw_sec
+                            end if
+                            return time_min as text & \":\" & time_sec as text
+                        end tell");
 fi
 
 if [ "$state" = "playing" ]; then
@@ -52,36 +107,53 @@ else
   state_icon="❚❚"
 fi
 
-suffix="..."
-trunc_length=20
-truncated_track=$track
-if [ ${#track} -gt $trunc_length ];then
-  truncated_track=${track:0:$trunc_length-${#suffic}}$suffix
+if [[ $CLEAN_TRACK_NAMES ]]; then
+  track="$(echo -e "${track/ - /\\n}" | head -n 1)"
+  track="$(echo -e "${track/ (Remastered/\\n}" | head -n 1)"
 fi
-truncated_artist=$artist
-if [ ${#artist} -gt $trunc_length ];then
-  truncated_artist=${artist:0:$trunc_length-${#suffic}}$suffix
-fi
-album=$(tellspotify 'album of current track as string');
 
-echo "$state_icon $truncated_track - $truncated_artist"
+## Truncate track and artist
+
+trunc_track=$track
+if [ ${#trunc_track} -gt $TRUNC_LEN ];then
+  trunc_track=${trunc_track:0:$TRUNC_LEN-${#TRUNC_SUFFIX}}$TRUNC_SUFFIX
+fi
+
+trunc_artist=$artist
+if [ ${#trunc_artist} -gt $TRUNC_LEN ];then
+  trunc_artist=${trunc_artist:0:$TRUNC_LEN-${#TRUNC_SUFFIX}}$TRUNC_SUFFIX
+fi
+
+## Print the display
+
+echo "$state_icon $trunc_track - $trunc_artist"
 echo "---"
 
-echo "Track: $track | color=#333333"
-echo "Artist: $artist | color=#333333"
-echo "Album: $album | color=#333333"
+echo -e "Track:\\t$track"
+echo -e "Artist:\\t$artist"
+echo -e "Album:\\t$album"
+echo "---"
 
-echo '---'
-echo "🎵 Lyrics | bash='$0' param1='lyrics' terminal=false"
-echo '---'
+if [[ $SHOW_TIME ]]; then
+  echo "${position} / ${duration}"
+  echo '---'
+fi
 
 if [ "$state" = "playing" ]; then
-  echo "⏸ Pause | bash='$0' param1=playpause terminal=false"
-  echo "⏮ Previous | bash='$0' param1='previous track' terminal=false refresh=true"
-  echo "⏭ Next | bash='$0' param1='next track' terminal=false refresh=true"
+  echo -e "❚❚\\tPause | bash='$0' param1=playpause terminal=false refresh=true"
+  echo -e "↩\\tPrevious | bash='$0' param1='set player position to 0;previous track' terminal=false refresh=true"
+  echo -e "↪\\tNext | bash='$0' param1='next track' terminal=false refresh=true"
+  echo -e "↻\\tReplay | bash = '$0' param1='set player position to 0' terminal=false"
 else
-  echo "▶️ Play | bash='$0' param1=playpause terminal=false"
+  echo -e "▶\\tPlay | bash='$0' param1=playpause terminal=false refresh=true"
+  echo -e "↩\\tPrevious | bash='$0' param1='set player position to 0;previous track;play' terminal=false refresh=true"
+  echo -e "↪\\tNext | bash='$0' param1='next track;play' terminal=false refresh=true"
+  echo -e "↻\\tReplay | bash = '$0' param1='set player position to 0;play' terminal=false refresh=true"
 fi
+
+echo '---'
+echo -e "♫\\tLyrics | bash='$0' param1='lyrics' terminal=false"
+echo '---'
 
 echo '---'
 echo "Open Spotify | bash='$0' param1=launch terminal=false"


### PR DESCRIPTION
Some bugfixes and QoL changes.

Note:

The buttons now are more DWIM [do what I mean] in spirit -- the idea is to not use the interface more than necessary. For example, pressing "Previous" will now seek to the beginning of the track and THEN go to the previous track. Previous was almost impossible to use before this change because you had to press it twice and be very quick about it. Furthermore, if the playback is currently paused, Previous and Next will additionally start playback, which is what is desired more often than not.

Full list of changes:

- Make 'prev track' seek to position 0 first.
- Correctly display the updated play state after pressing play/pause.
- Make prev/next play the prev/next track if playback is currently paused.
- Fix the track/artist/album info being unreadable on a dark menu bar.
- Remove unnecessary "Remastered" etc from track name (optional).
- Fix truncation not working properly (the "suffix" variable was typo'd as "suffic").
- Implement nicer track/artist/album display.
- Display track position and total duration (optional).

Considered but not included:

- Scrolling, i.e. horizontal scrolling for truncated text to reveal the truncated part. This works best with a higher refresh rate, but a refresh rate of 1 s compared to 10 s makes this script raise my machine's temperature by 2 degrees Fahrenheit. Perhaps once [this](https://github.com/matryer/bitbar/pull/393) gets merged we can revisit this idea (see also [this](https://github.com/matryer/bitbar/issues/457))

How I imagined this would work:

> The variable "$SCROLL" can be set to "false" to turn off scrolling. Scrolling text will not display the "..." indicator. This requires a higher refresh rate to work well.