### PR TITLE
clipboard-history icon replace

### DIFF
--- a/System/clipboard-history.3s.sh
+++ b/System/clipboard-history.3s.sh
@@ -62,7 +62,7 @@ if [ "$CLIPBOARD" != "" ]; then
 fi
 
 # Print icon
-echo '📋'
+echo '✄'
 echo "---"
 
 # Print up to 36 characters of the current clipboard


### PR DESCRIPTION
I think this icon looks better.

![screen shot 2018-05-30 at 12 31 59](https://user-images.githubusercontent.com/1009639/40712147-a8f5db14-6405-11e8-8194-2b17a9c38cb0.png)
