### PR TITLE
Add -L flag for the curl to unsplash

### DIFF
--- a/Lifestyle/unsplash-background.3h.sh
+++ b/Lifestyle/unsplash-background.3h.sh
@@ -15,7 +15,7 @@ echo '|templateImage=iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAABG2lUWHRYTUw
 echo '---'
 echo 'Next Image | refresh=true'
 
-curl --silent -o /tmp/.background.png "https://unsplash.it/2560/1600/?random"
+curl -L --silent -o /tmp/.background.png "https://unsplash.it/2560/1600/?random"
 
 sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '/tmp/.background.png'"
 


### PR DESCRIPTION
The unsplash random route must have changed since this script was first written. On my version of curl(7.52.1 macos), curl does not follow the 302 redirect without the -L flag. Adding it fixes the functionality.


```
rlyshw in ~/.bitbar
⚡ curl --version
curl 7.52.1 (x86_64-apple-darwin13.4.0) libcurl/7.52.1 OpenSSL/1.0.2l zlib/1.2.8
Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP UnixSockets HTTPS-proxy
```