### PR TITLE
Add support for lua plugins + network bandwidth plugin in lua

### DIFF
--- a/.test.py
+++ b/.test.py
@@ -104,6 +104,7 @@ Language.registerLanguage(Language(['.lisp', '.clisp'], 'clisp$', ['clisp']))
 Language.registerLanguage(Language(['.rkt'], 'racket$', ['raco', 'make']))
 # go does not actually support shebang on line 1.  gorun works around this, so we need to strip it before we lint
 Language.registerLanguage(Language(['.go'], 'gorun$', ['golint', '-set_exit_status'], trim_shebang=True))
+Language.registerLanguage(Language(['.lua'], 'lua$', ['luacheck']))
 
 
 def check_file(file_full_path, pr=False):

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ before_install:
   - brew outdated golang || brew upgrade golang
   - go get -u github.com/golang/lint/golint
   - brew cask install racket
-  - raco pkg install --deps search-auto rackjure  
+  - raco pkg install --deps search-auto rackjure
+  - brew install lua
+  - luarocks install luacheck
 install:
   - export PATH="$PATH:${GOROOT:-$HOME/go}/bin"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
   - pip3 install pyflakes
   - gem install rubocop -v 0.50.0 --no-document
   - brew install shellcheck
+  - brew install luarocks
+  - luarocks install luacheck
   - brew outdated node || brew upgrade node
   - npm install -g jshint
   - brew install cpanminus && sudo cpanm Mozilla::CA
@@ -19,8 +21,6 @@ before_install:
   - go get -u github.com/golang/lint/golint
   - brew cask install racket
   - raco pkg install --deps search-auto rackjure
-  - brew install lua
-  - luarocks install luacheck
 install:
   - export PATH="$PATH:${GOROOT:-$HOME/go}/bin"
 

--- a/Network/bandwidth_total.2s.lua
+++ b/Network/bandwidth_total.2s.lua
@@ -7,7 +7,9 @@
 -- <bitbar.version>v1.0.0</bitbar.version>
 -- <bitbar.author>Charl P. Botha</bitbar.author>
 -- <bitbar.author.github>cpbohta</bitbar.author.github>
--- <bitbar.desc>Displays total TX and RX KBytes/s only for the interfaces you specify, with the individual ifaces in the context menu. Written in lua with single shell call to ifstat. Faster and smaller than .sh versions.</bitbar.desc>
+-- <bitbar.desc>Displays total TX and RX KBytes/s only for the interfaces you specify,
+-- with the individual ifaces in the context menu. Written in lua with single shell call to ifstat.
+-- Faster and smaller than .sh versions.</bitbar.desc>
 -- <bitbar.dependencies>ifstat, lua</bitbar.dependencies>
 -- <bitbar.image>https://cpbotha.net/thingies/bitbar_bandwidth_total_lua.jpg</bitbar.image>
 
@@ -24,17 +26,17 @@ local output = file:read('*all')
 
 -- split into lines
 -- https://stackoverflow.com/a/32847589/532513
-lines = {}
+local lines = {}
 for l in output:gmatch("[^\r\n]+") do
     table.insert(lines, l)
 end
 
-speeds = {}
+local speeds = {}
 for speed in lines[3]:gmatch("%S+") do
     table.insert(speeds, speed)
 end
 
-ifaces = {}
+local ifaces = {}
 for iface in lines[1]:gmatch("%S+") do
     table.insert(ifaces, iface)
 end

--- a/Network/bandwidth_total.2s.lua
+++ b/Network/bandwidth_total.2s.lua
@@ -1,0 +1,51 @@
+#!/usr/local/bin/lua
+
+-- 1. install lua with e.g. "brew install lua"
+-- 2. edit ifstat invocation below so that "-i en0,en10" contains your preferred list of interfaces
+
+-- <bitbar.title>Bandwidth Total</bitbar.title>
+-- <bitbar.version>v1.0.0</bitbar.version>
+-- <bitbar.author>Charl P. Botha</bitbar.author>
+-- <bitbar.author.github>cpbohta</bitbar.author.github>
+-- <bitbar.desc>Displays total TX and RX KBytes/s only for the interfaces you specify, with the individual ifaces in the context menu. Written in lua with single shell call to ifstat. Faster and smaller than .sh versions.</bitbar.desc>
+-- <bitbar.dependencies>ifstat, lua</bitbar.dependencies>
+-- <bitbar.image>https://cpbotha.net/thingies/bitbar_bandwidth_total_lua.jpg</bitbar.image>
+
+-- to find the network interface connected to default route you could use this:
+-- https://superuser.com/a/627581/130835
+
+-- use ifstat to read current network throughput
+-- example output:
+--        en0                 en10               Total
+-- KB/s in  KB/s out   KB/s in  KB/s out   KB/s in  KB/s out
+-- 20.67      0.00     17.54      0.00     38.21      0.00
+local file = io.popen('/usr/local/bin/ifstat -n -w -i en0,en10 -T 0.1 1')
+local output = file:read('*all')
+
+-- split into lines
+-- https://stackoverflow.com/a/32847589/532513
+lines = {}
+for l in output:gmatch("[^\r\n]+") do
+    table.insert(lines, l)
+end
+
+speeds = {}
+for speed in lines[3]:gmatch("%S+") do
+    table.insert(speeds, speed)
+end
+
+ifaces = {}
+for iface in lines[1]:gmatch("%S+") do
+    table.insert(ifaces, iface)
+end
+
+-- lua tables start from 1
+-- #name is the number of elements, so name[#name] will give you the last element
+print(string.format("▼%.2f ▲%.2f", speeds[#speeds-1], speeds[#speeds]))
+print("---")
+
+for i = 1,#ifaces-1 do
+    -- remember lua is 1-based (hence the *2+1 and *2+2)
+    -- speeds are already %.2f formatted strings, or "n/a" if iface not available
+    print(string.format("%s: ▼%s ▲%s", ifaces[i], speeds[i*2-1], speeds[i*2]))
+end

--- a/Network/bandwidth_total.2s.lua
+++ b/Network/bandwidth_total.2s.lua
@@ -1,7 +1,7 @@
 #!/usr/local/bin/lua
 
 -- 1. install lua with e.g. "brew install lua"
--- 2. edit ifstat invocation below so that "-i en0,en10" contains your preferred list of interfaces
+-- 2. use this plugin
 
 -- Written in lua, this plugin is smaller and faster than shell versions with similar function.
 
@@ -9,7 +9,7 @@
 -- <bitbar.version>v1.0.0</bitbar.version>
 -- <bitbar.author>Charl P. Botha</bitbar.author>
 -- <bitbar.author.github>cpbotha</bitbar.author.github>
--- <bitbar.desc>Displays total TX and RX KBytes/s for the interfaces you specify. Lua = smaller than .sh.</bitbar.desc>
+-- <bitbar.desc>Displays total TX and RX KBytes/s for all active interfaces. Lua = smaller than .sh.</bitbar.desc>
 -- <bitbar.dependencies>ifstat, lua</bitbar.dependencies>
 -- <bitbar.image>https://cpbotha.net/thingies/bitbar_bandwidth_total_lua.jpg</bitbar.image>
 
@@ -21,7 +21,7 @@
 --        en0                 en10               Total
 -- KB/s in  KB/s out   KB/s in  KB/s out   KB/s in  KB/s out
 -- 20.67      0.00     17.54      0.00     38.21      0.00
-local file = io.popen('/usr/local/bin/ifstat -n -w -i en0,en10 -T 0.1 1')
+local file = io.popen('/usr/local/bin/ifstat -n -w -z -T 0.1 1')
 local output = file:read('*all')
 
 -- split into lines

--- a/Network/bandwidth_total.2s.lua
+++ b/Network/bandwidth_total.2s.lua
@@ -3,13 +3,13 @@
 -- 1. install lua with e.g. "brew install lua"
 -- 2. edit ifstat invocation below so that "-i en0,en10" contains your preferred list of interfaces
 
+-- Written in lua, this plugin is smaller and faster than shell versions with similar function.
+
 -- <bitbar.title>Bandwidth Total</bitbar.title>
 -- <bitbar.version>v1.0.0</bitbar.version>
 -- <bitbar.author>Charl P. Botha</bitbar.author>
--- <bitbar.author.github>cpbohta</bitbar.author.github>
--- <bitbar.desc>Displays total TX and RX KBytes/s only for the interfaces you specify,
--- with the individual ifaces in the context menu. Written in lua with single shell call to ifstat.
--- Faster and smaller than .sh versions.</bitbar.desc>
+-- <bitbar.author.github>cpbotha</bitbar.author.github>
+-- <bitbar.desc>Displays total TX and RX KBytes/s for the interfaces you specify. Lua = smaller than .sh.</bitbar.desc>
 -- <bitbar.dependencies>ifstat, lua</bitbar.dependencies>
 -- <bitbar.image>https://cpbotha.net/thingies/bitbar_bandwidth_total_lua.jpg</bitbar.image>
 


### PR DESCRIPTION
This plugin shows current total bandwidth over user-specified interfaces, with separate interfaces in context menu.

It is written in lua with a single call to ifstat. It is 30% smaller (peak memory use) and slightly faster than the bash + ifstat + awk versions.