### PR TITLE
Update golint install step to fix Travis CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - brew install cpanminus && sudo cpanm Mozilla::CA
   - brew install clisp
   - brew outdated golang || brew upgrade golang
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - brew cask install racket
   - raco pkg install --deps search-auto rackjure
 install:


### PR DESCRIPTION

Travis CI is failing on some recent pull request builds:

- [Build #2009](https://travis-ci.org/matryer/bitbar-plugins/builds/444790176)
- [Build #2003](https://travis-ci.org/matryer/bitbar-plugins/builds/441034070)

The `go get -u github.com/golang/lint/golint` step in the Travis CI results in the following error:

```sh
$ go get -u github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /Users/travis/go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"

The command "go get -u github.com/golang/lint/golint" failed and exited with 1 during .

Your build has been stopped.
```

The step has been changed to `go get -u golang.org/x/lint/golint` according to the installation instructions in the [Golint](https://github.com/golang/lint) README. This should hopefully fix the Travis CI build.