### PR TITLE
ituneRating.sh: inhibit the error message when no song is playing

### DIFF
--- a/Music/itunesRating.10s.sh
+++ b/Music/itunesRating.10s.sh
@@ -62,9 +62,9 @@ fi
 rating_icon_black="★"
 rating_icon_white="☆"
 
-track=$(osascript -e 'tell application "iTunes" to name of current track as string');
-artist=$(osascript -e 'tell application "iTunes" to artist of current track as string');
-rating=$(osascript -e 'tell application "iTunes" to rating of current track as string');
+track=$(osascript -e 'tell application "iTunes" to name of current track as string' 2>/dev/null);
+artist=$(osascript -e 'tell application "iTunes" to artist of current track as string' 2>/dev/null);
+rating=$(osascript -e 'tell application "iTunes" to rating of current track as string' 2>/dev/null);
 
 case $rating in
     00)

--- a/Music/itunesRating.10s.sh
+++ b/Music/itunesRating.10s.sh
@@ -134,3 +134,4 @@ echo "$rating_icon_black $rating_icon_white $rating_icon_white $rating_icon_whit
 echo "$rating_icon_black $rating_icon_black $rating_icon_white $rating_icon_white $rating_icon_white | bash='$0' param1=two refresh=true terminal=false "
 echo "$rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_white $rating_icon_white | bash='$0' param1=three refresh=true terminal=false "
 echo "$rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_white | bash='$0' param1=four refresh=true terminal=false "
+echo "$rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_black | bash='$0' param1=five refresh=true terminal=false "

--- a/Music/itunesRating.10s.sh
+++ b/Music/itunesRating.10s.sh
@@ -134,4 +134,3 @@ echo "$rating_icon_black $rating_icon_white $rating_icon_white $rating_icon_whit
 echo "$rating_icon_black $rating_icon_black $rating_icon_white $rating_icon_white $rating_icon_white | bash='$0' param1=two refresh=true terminal=false "
 echo "$rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_white $rating_icon_white | bash='$0' param1=three refresh=true terminal=false "
 echo "$rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_white | bash='$0' param1=four refresh=true terminal=false "
-echo "$rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_black $rating_icon_black | bash='$0' param1=five refresh=true terminal=false "

--- a/Time/CalendarLite.1m.sh
+++ b/Time/CalendarLite.1m.sh
@@ -25,7 +25,7 @@ echo "Last month: $last_m_name, $year|trim=false font=$font"
 cal -d "$year"-"$last_m" |awk 'NF'|sed 's/ *$//'| while IFS= read -r i; do echo "--$i|trim=false font=$font"; done 
 echo "---"
 
-cal |awk 'NF'|sed 's/ $//' |while IFS= read -r i; do echo " $i|trim=false font=$font color=$color"|  perl -pe '$b="\b";s/ _$b(\d)_$b(\d) /(\1\2)/' |perl -pe '$b="\b";s/_$b _$b(\d) /(\1)/' ; done
+cal |awk 'NF'|sed 's/ $//' |while IFS= read -r i; do echo " $i|trim=false font=$font color=$color"|  perl -pe '$b="\b";s/ _$b(\d)_$b(\d)/(\1\2)/' |perl -pe '$b="\b";s/_$b _$b(\d)/(\1)/' ; done
 
 #Comment out these lines to remove "next month"
 echo "---"


### PR DESCRIPTION
When no song is selected, the ituneRating script shows an error message like this:
<img width="779" alt="before_fix_itunerating" src="https://user-images.githubusercontent.com/25602873/49403583-fdce8c00-f701-11e8-8481-e9a8d4cbeaa7.png">

After the fix, it looks like this:
<img width="183" alt="fix_itunerating" src="https://user-images.githubusercontent.com/25602873/49403601-0921b780-f702-11e8-8c05-79175f5d9aab.png">
