### PR TITLE
Encoding issue with yahoo-weather

### DIFF
--- a/Weather/yahoo_temp.5m.py
+++ b/Weather/yahoo_temp.5m.py
@@ -13,7 +13,10 @@
 
 import urllib
 import json
+import sys
 
+reload(sys)
+sys.setdefaultencoding('utf8')
 ip_url = 'http://ip-api.com/json'
 
 try:


### PR DESCRIPTION
There is an issue with encoding throwing this error.
```
Traceback (most recent call last):
  File "yahoo_temp.5m.py", line 26, in <module>
    city = str(j['city'])
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfd' in position 23: ordinal not in range(128)
```
I've implemented a quick fix so now it works correctly.