### PR TITLE
[Web/Hacker News] Add an item to manually refresh plugin (feed) when internet connection isn't available

### DIFF
--- a/Web/HackerNews/hn_front.120m.py
+++ b/Web/HackerNews/hn_front.120m.py
@@ -18,6 +18,7 @@ try:
 except exceptions.RequestException:    
     print('---')
     print("Internet Connection Not available")
+    print("Manually refresh | refresh = true")
     exit(1)
 ids = content.json()
 story_base = "https://hacker-news.firebaseio.com/v0/item/"


### PR DESCRIPTION
If internet isn't up by the time the plugin loads, the user must wait 120 minutes before the plugin will refresh. This allows the user to manually refresh the plugin, thereby refreshing the feed.

Original contributor: @amrrs 