### PR TITLE
Don't print non-posix album art image filename

### DIFF
--- a/Music/itunes.10s.sh
+++ b/Music/itunes.10s.sh
@@ -159,7 +159,6 @@ if [ ! -f "$tmp_file" ]; then
             save resImg
             close resImg
         end tell
-        tmpName
     on error errText
         ""
     end try


### PR DESCRIPTION
The first time the script runs on a new track it will print the non-posix filename as the first line of output and display it in the menu bar instead of the music notes, state_icon and track + artist.

Example screenshot - https://www.dropbox.com/s/n7jvqw2nnr92p68/Screenshot%202019-02-16%2013.06.12.png?dl=0