### PR TITLE
Remove color=black so that HackerNews supports dark mode

### DIFF
--- a/Web/HackerNews/hacker_news.1m.rb
+++ b/Web/HackerNews/hacker_news.1m.rb
@@ -101,7 +101,7 @@ def print_title(title)
 end
 
 def print(s)
-  puts "#{s[:title]} | href=#{s[:url]} color=black"
+  puts "#{s[:title]} | href=#{s[:url]}"
   puts "Score: #{s[:score]} Comments: #{s[:descendants]} | href=#{'https://news.ycombinator.com/item?id=' + s[:id].to_s} color=#FF6600"
   puts '---'
 end


### PR DESCRIPTION
I'd like to let HackerNews plugin support dark mode.