### PR TITLE
Use threading in slack-unread

### DIFF
--- a/Messenger/slack-unread.1s.py
+++ b/Messenger/slack-unread.1s.py
@@ -172,7 +172,8 @@ def privates(token):
 		
 		
 for token in tokens:
-	print('Processing token: %s' % (token))
+	if debug_mode:
+		print('Processing token: %s' % (token))
 	g = Thread(target=groups, args=(token,))
 	c = Thread(target=channels, args=(token,))
 	p = Thread(target=privates, args=(token,))


### PR DESCRIPTION
The previous implementation took my machine about 4.5 seconds to execute due to requests. By using threads to minimize the request waiting time, I managed to achieve under 0.8 second execution time.