### PR TITLE
[UPDATE] jq path + [FIX] base64 Image Decoding

### DIFF
--- a/Web/commitstrip.1h.sh
+++ b/Web/commitstrip.1h.sh
@@ -10,16 +10,17 @@
 echo "| image=/9j/4AAQSkZJRgABAQAAAQABAAD//gAgQ29tcHJlc3NlZCBieSBqcGVnLXJlY29tcHJlc3MA/9sAhAADAwMDAwMEBAQEBQUFBQUHBwYGBwcLCAkICQgLEQsMCwsMCxEPEg8ODxIPGxUTExUbHxoZGh8mIiImMC0wPj5UAQMDAwMDAwQEBAQFBQUFBQcHBgYHBwsICQgJCAsRCwwLCwwLEQ8SDw4PEg8bFRMTFRsfGhkaHyYiIiYwLTA+PlT/wgARCAAQABADASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAABAUH/9oACAEBAAAAAMPam/8A/8QAFAEBAAAAAAAAAAAAAAAAAAAAB//aAAgBAhAAAABA/8QAFAEBAAAAAAAAAAAAAAAAAAAABv/aAAgBAxAAAAA//8QAIhAAAgICAgICAwAAAAAAAAAAAgQBAwUSBhEAEwcUIkFR/9oACAEBAAE/AHOHq4zAqPP5xOh11KXFsfpaZlTJahuYDIgZ9TIj/POSfG73F8Enkncoh7WV1r4SgGRt9bQRYEgZ1DVb1Extoc9eMcw4o+mmxkcAy7llcVSgG7mifS9fqquKsBgyIRiPx3iO48b+UsSXDcpx9VDLxQ+rTUCLOS+yglaBic3LVnXuE9jPUbfvz//EABsRAAEEAwAAAAAAAAAAAAAAAAIAARExBCIy/9oACAECAQE/ACLKkIZ+9qpf/8QAGBEAAgMAAAAAAAAAAAAAAAAAASEAA0H/2gAIAQMBAT8AArbxT//Z"
 echo ---
 
+JQ=$(command -v jq)
 CURL=$(curl --silent "http://www.commitstrip.com/en/wp-json/wp/v2/posts?per_page=100")
-IMG_NUM=$(echo "${CURL}" | /usr/local/bin/jq -r 'length')
+IMG_NUM=$(echo "${CURL}" | $JQ -r 'length')
 IMG_RAND=$(( ( RANDOM % IMG_NUM )  + 1 ))
-ID=$(echo "${CURL}" | /usr/local/bin/jq -r ".[$IMG_RAND].id")
+ID=$(echo "${CURL}" | $JQ -r ".[$IMG_RAND].id")
 
 CURL=$(curl --silent "http://www.commitstrip.com/en/wp-json/wp/v2/posts/$ID")
-IMG_URL=$(echo "${CURL}" | /usr/local/bin/jq -r '.content.rendered | match("http[^ \"]+") | .string')
-LINK=$(echo "${CURL}" | /usr/local/bin/jq -r '.link')
-TITLE=$(echo "${CURL}" | /usr/local/bin/jq -r '.title.rendered')
-IMAGE=$(base64 <(curl --silent "$IMG_URL"))
+IMG_URL=$(echo "${CURL}" | $JQ -r '.content.rendered | match("http[^ \"]+") | .string')
+LINK=$(echo "${CURL}" | $JQ -r '.link')
+TITLE=$(echo "${CURL}" | $JQ -r '.title.rendered')
+IMAGE=$(base64 -w 0 <(curl --silent "$IMG_URL"))
 echo "| image=$IMAGE"
 echo ---
 echo "$TITLE | size=14 href='$LINK'"


### PR DESCRIPTION
- __jq path__: On my machine, `jq` path is not `/usr/local/bin/jq` it's `/usr/bin/jq`. 
To match all jq installs (`/usr/local/bin/jq`, `/usr/bin/jq`, `~/bin/jq` or `whatever jq path`) we can use `command -v jq` to get current `jq` path.
- __base64 Image Decoding__: On my system I need to disable line wrapping by using the `-w 0` to make it work properly