### PR TITLE
Wifi Signal Strength & Quality

### DIFF
--- a/Network/wifisignal.sh
+++ b/Network/wifisignal.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# <bitbar.title>Active WIFI Signal</bitbar.title>
+# <bitbar.author>Bryan Stone</bitbar.author>
+# <bitbar.author.github>aegixx</bitbar.author.github>
+# <bitbar.desc>Displays currently connected WIFI Signal</bitbar.desc>
+
+# Themes copied from here: http://colorbrewer2.org/
+# shellcheck disable=SC2034
+RED_GREEN_THEME=("#d73027" "#fc8d59" "#fee08b" "#d9ef8b" "#91cf60" "#1a9850")
+COLORS=(${RED_GREEN_THEME[@]})
+
+WIFIDATA=$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I)
+SSID=$(echo "$WIFIDATA" | awk '/ SSID/ {print substr($0, index($0, $2))}')
+SIGNAL=$(echo "$WIFIDATA" | awk '/ agrCtlRSSI/ {print substr($0, index($0, $2))}')
+NOISE=$(echo "$WIFIDATA" | awk '/ agrCtlNoise/ {print substr($0, index($0, $2))}')
+
+SNR=$(($SIGNAL - $NOISE))
+
+# Signal Strength – 0dBm (strongest) and --100dBm (weakest). 
+## -30 dBm  Amazing
+## -50 dBm	Excellent
+## -60 dBm	Good
+## -67 dBm	Reliable
+## -70 dBm	Okay
+## -80 dBm	Not Good
+## -90 dBm	Unusable
+if (($SIGNAL >= -30)); then
+    RATING="Amazing"
+    COLOR=${COLORS[6]}
+elif (($SIGNAL >= -50)); then
+    RATING="Excellent"
+    COLOR=${COLORS[5]}
+elif (($SIGNAL >= -60)); then
+    RATING="Good"
+    COLOR=${COLORS[4]}
+elif (($SIGNAL >= -67)); then
+    RATING="Reliable"
+    COLOR=${COLORS[3]}
+elif (($SIGNAL >= -70)); then
+    RATING="Okay"
+    COLOR=${COLORS[2]}
+elif (($SIGNAL >= -80)); then
+    RATING="Not Good"
+    COLOR=${COLORS[1]}
+elif (($SIGNAL >= -90)); then
+    RATING="Unusable"
+    COLOR=${COLORS[0]}
+else
+    RATING="Unknown"
+    COLOR="#ccc"
+fi
+
+# Signal Quality - quality ~= 2* (dBm + 100)
+## High quality: 90% ~= -55dBm
+## Medium quality: 50% ~= -75dBm
+## Low quality: 30% ~= -85dBm
+## Unusable quality: 8% ~= -96dBm
+QUALITY=$((2 * $SNR))
+QUALITY=$((QUALITY < 100 ? QUALITY : 100))
+
+echo "📶 $SSID | color=$COLOR"
+echo "---"
+echo "Signal: $SIGNAL ($RATING)"
+echo "Quality: $QUALITY% ($SNR dBm)"
+echo "---"
+echo "Refresh... | refresh=true"

--- a/Network/wifisignal.sh
+++ b/Network/wifisignal.sh
@@ -61,7 +61,7 @@ QUALITY=$((QUALITY < 100 ? QUALITY : 100))
 
 echo "📶 $SSID | color=$COLOR"
 echo "---"
-echo "Signal: $SIGNAL ($RATING)"
-echo "Quality: $QUALITY% ($SNR dBm)"
+echo "Signal: $SIGNAL dbM ($RATING)"
+echo "Quality: $QUALITY% ($SNR dBm SNR)"
 echo "---"
 echo "Refresh... | refresh=true"

--- a/Network/wifisignal.sh
+++ b/Network/wifisignal.sh
@@ -15,7 +15,7 @@ SSID=$(echo "$WIFIDATA" | awk '/ SSID/ {print substr($0, index($0, $2))}')
 SIGNAL=$(echo "$WIFIDATA" | awk '/ agrCtlRSSI/ {print substr($0, index($0, $2))}')
 NOISE=$(echo "$WIFIDATA" | awk '/ agrCtlNoise/ {print substr($0, index($0, $2))}')
 
-SNR=$(("$SIGNAL" - "$NOISE"))
+SNR="$((SIGNAL - NOISE))"
 
 # Signal Strength – 0dBm (strongest) and --100dBm (weakest). 
 ## -30 dBm  Amazing
@@ -56,8 +56,8 @@ fi
 ## Medium quality: 50% ~= -75dBm
 ## Low quality: 30% ~= -85dBm
 ## Unusable quality: 8% ~= -96dBm
-QUALITY=$((2 * "$SNR"))
-QUALITY=$((QUALITY < 100 ? QUALITY : 100))
+QUALITY="$((2 * SNR))"
+QUALITY="$((QUALITY < 100 ? QUALITY : 100))"
 
 echo "📶 $SSID | color=$COLOR"
 echo "---"

--- a/Network/wifisignal.sh
+++ b/Network/wifisignal.sh
@@ -8,14 +8,14 @@
 # Themes copied from here: http://colorbrewer2.org/
 # shellcheck disable=SC2034
 RED_GREEN_THEME=("#d73027" "#fc8d59" "#fee08b" "#d9ef8b" "#91cf60" "#1a9850")
-COLORS=(${RED_GREEN_THEME[@]})
+COLORS=("${RED_GREEN_THEME[@]}")
 
 WIFIDATA=$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I)
 SSID=$(echo "$WIFIDATA" | awk '/ SSID/ {print substr($0, index($0, $2))}')
 SIGNAL=$(echo "$WIFIDATA" | awk '/ agrCtlRSSI/ {print substr($0, index($0, $2))}')
 NOISE=$(echo "$WIFIDATA" | awk '/ agrCtlNoise/ {print substr($0, index($0, $2))}')
 
-SNR=$(($SIGNAL - $NOISE))
+SNR=$(("$SIGNAL" - "$NOISE"))
 
 # Signal Strength – 0dBm (strongest) and --100dBm (weakest). 
 ## -30 dBm  Amazing
@@ -25,25 +25,25 @@ SNR=$(($SIGNAL - $NOISE))
 ## -70 dBm	Okay
 ## -80 dBm	Not Good
 ## -90 dBm	Unusable
-if (($SIGNAL >= -30)); then
+if (("$SIGNAL" >= -30)); then
     RATING="Amazing"
     COLOR=${COLORS[6]}
-elif (($SIGNAL >= -50)); then
+elif (("$SIGNAL" >= -50)); then
     RATING="Excellent"
     COLOR=${COLORS[5]}
-elif (($SIGNAL >= -60)); then
+elif (("$SIGNAL" >= -60)); then
     RATING="Good"
     COLOR=${COLORS[4]}
-elif (($SIGNAL >= -67)); then
+elif (("$SIGNAL" >= -67)); then
     RATING="Reliable"
     COLOR=${COLORS[3]}
-elif (($SIGNAL >= -70)); then
+elif (("$SIGNAL" >= -70)); then
     RATING="Okay"
     COLOR=${COLORS[2]}
-elif (($SIGNAL >= -80)); then
+elif (("$SIGNAL" >= -80)); then
     RATING="Not Good"
     COLOR=${COLORS[1]}
-elif (($SIGNAL >= -90)); then
+elif (("$SIGNAL" >= -90)); then
     RATING="Unusable"
     COLOR=${COLORS[0]}
 else
@@ -56,7 +56,7 @@ fi
 ## Medium quality: 50% ~= -75dBm
 ## Low quality: 30% ~= -85dBm
 ## Unusable quality: 8% ~= -96dBm
-QUALITY=$((2 * $SNR))
+QUALITY=$((2 * "$SNR"))
 QUALITY=$((QUALITY < 100 ? QUALITY : 100))
 
 echo "📶 $SSID | color=$COLOR"


### PR DESCRIPTION
New plugin that utilizes the `airport` CLI tool to grab the active wifi signal & noise data, then perform basic calculations to show signal strength & quality.

![image](https://user-images.githubusercontent.com/7032283/63643532-43175d00-c687-11e9-9895-ad8f4fab5cb6.png)
![image](https://user-images.githubusercontent.com/7032283/63643534-4ca0c500-c687-11e9-883b-60aaf986e3a5.png)

Signed-off-by: Bryan Stone <aegixx@gmail.com>