### PR TITLE
fixed posix error no 2

### DIFF
--- a/System/Battery/battery-status.20s.py
+++ b/System/Battery/battery-status.20s.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # <bitbar.title>Battery remaining (Python)</bitbar.title>
 # <bitbar.version>v1.0.0</bitbar.version>


### PR DESCRIPTION
Fixed an error that'll happen on a machine that uses 2 or more version of python.
BitBar plugin will utilize the default system python version.