### PR TITLE
fix battery plugin and ensure we use python 3

### DIFF
--- a/System/Battery/battery-status.20s.py
+++ b/System/Battery/battery-status.20s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
 # -*- coding: utf-8 -*-
 # <bitbar.title>Battery remaining (Python)</bitbar.title>
 # <bitbar.version>v1.0.0</bitbar.version>
@@ -41,7 +41,7 @@ def parse_pmset():
 
 def main():
     battery = parse_pmset()
-    refresh_interval = sys.argv[0].split('.')[2]
+    refresh_interval = sys.argv[0].split('.')[1]
     print("{}| size=12".format(battery["charge"]))
     print("---")
     print("Status: {}".format(battery["status"]))


### PR DESCRIPTION
Fixes problems referenced in #1130 and #1309 by using the right split of the output and ensuring we use python3