### PR TITLE
add image metadata for the cloudwatch alarm plugin

### DIFF
--- a/AWS/cloudwatch-alarms.30s.py
+++ b/AWS/cloudwatch-alarms.30s.py
@@ -7,6 +7,7 @@
 # <bitbar.author.github>sebasrp</bitbar.author.github>
 # <bitbar.desc>Monitor the status of your CloudWatch Alarms</bitbar.desc>
 # <bitbar.dependencies>python, boto3</bitbar.dependencies>
+# <bitbar.image>https://i.imgur.com/qiqHX32.png</bitbar.image>
 
 import boto3
 


### PR DESCRIPTION
Adding image metadata to the plugin so that the website https://getbitbar.com/plugins/AWS displays the image alongside the plugin