### PR TITLE
fix: nowplaying support for Catalina Music.app

### DIFF
--- a/Music/nowplaying.5s.sh
+++ b/Music/nowplaying.5s.sh
@@ -10,7 +10,7 @@
 # <bitbar.abouturl></bitbar.abouturl>
 
 # first, determine if there's an app that's playing or paused
-apps=(Spotify iTunes Vox)
+apps=(iTunes Music Spotify Vox)
 playing=""
 paused=""
 


### PR DESCRIPTION
macOS Catalina rebranded `/Applicaitons/iTunes.app` to `/System/Applications/Music.app`.

This will add support for Apple's native Music app... tested working in 10.15.1... and immediately takes effect (upon next refresh), no app restart necessary.