### PR TITLE
Fix Ruby 2.7.0 deprecation warning

### DIFF
--- a/Dev/GitHub/github-contribution.10m.rb
+++ b/Dev/GitHub/github-contribution.10m.rb
@@ -81,7 +81,7 @@ module BitBar
 
       def self.find_all_by(username:)
         [].tap do |contributions|
-          html = open(url_for(username: username)) { |f| f.read }
+          html = URI.send(:open, url_for(username: username)) { |f| f.read }
 
           html.scan(RE_CONTRIBUTION) do |count, date|
             contributions << Contribution.new(username, Date.parse(date), count.to_i)


### PR DESCRIPTION
Fixed following warn:

```rb
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```