### PR TITLE
Update keyboard-system_profiler.1m.rb

### DIFF
--- a/System/Battery/keyboard-system_profiler.1m.rb
+++ b/System/Battery/keyboard-system_profiler.1m.rb
@@ -12,7 +12,7 @@
 
 require 'yaml'
 
-output = YAML.load(`system_profiler SPBluetoothDataType`);
+output = YAML.load(`system_profiler SPBluetoothDataType 2> /dev/null`);
 
 output['Bluetooth']['Devices (Paired, Configured, etc.)'].each do |device|
         puts "Keyboard: "+device[1]['Battery Level'].to_s if device[1]['Minor Type'].eql?('Keyboard') && device[1].has_key?('Battery Level')


### PR DESCRIPTION
Output of `system_profiler` command returns to STDERR the following lines, which cause the plug in to display a ⚠️ next to the battery percentage.

Simply including a redirect of STDERR clears that issue.

```
2020-03-11 10:48:07.833 system_profiler[8531:9341301] SystemInfo-AccessoryFW from dict - xxxx's Mouse = 0x0102
2020-03-11 10:48:07.836 system_profiler[8531:9341301] SystemInfo-AccessoryFW from dict - xxxx’s Keyboard = 0x0100
2020-03-11 10:48:07.837 system_profiler[8531:9341301] SystemInfo-AccessoryFW from dict - xxx xxx = 0x0106
```