### PR TITLE
fix: add music-controls support for Catalina Music.app

### DIFF
--- a/Music/music-controls-info.10s.sh
+++ b/Music/music-controls-info.10s.sh
@@ -10,7 +10,7 @@
 # <bitbar.version>v1.0</bitbar.version>
 # <bitbar.author>Sebastián Barschkis</bitbar.author>
 # <bitbar.author.github>sebbas</bitbar.author.github>
-# <bitbar.desc>Plays the next track in cmus, iTunes, Spotify or pianobar.</bitbar.desc>
+# <bitbar.desc>Plays the next track in cmus, iTunes, Music, Spotify or pianobar.</bitbar.desc>
 # <bitbar.dependencies>perl</bitbar.dependencies>
 # <bitbar.image>https://raw.githubusercontent.com/sebbas/music-controls-bitbar/master/music-controls-screenshot.png</bitbar.image>
 # <bitbar.abouturl>http://github.com/sebbas/music-controls-bitbar</bitbar.abouturl>
@@ -31,6 +31,7 @@ EXPERIMENTAL_MODE=0
 NONE="none"
 CMUS="cmus"
 ITUNES="iTunes"
+MUSIC="Music"
 SPOTIFY="Spotify"
 PIANOBAR="pianobar"
 
@@ -62,6 +63,10 @@ if [[ "$1" = 'itunes_next' ]]; then
   osascript -e 'tell application "iTunes" to next track'
   exit
 fi
+if [[ "$1" = 'music_next' ]]; then
+  osascript -e 'tell application "Music" to next track'
+  exit
+fi
 if [[ "$1" = 'spotify_next' ]]; then
   osascript -e 'tell application "Spotify" to next track'
   exit
@@ -82,18 +87,22 @@ current_source="$NONE"
 # Get pid of music apps to see if they are currently running
 cmus_pid=$(pgrep -x "$CMUS")
 itunes_pid=$(pgrep -x "$ITUNES")
+music_pid=$(pgrep -x "$MUSIC")
 spotify_pid=$(pgrep -x "$SPOTIFY")
 pianobar_pid=$(pgrep -x "$PIANOBAR")
 
 # Keep track of music source
 # Reorder items in for -loop to your liking to change order of precendece
 # (i.e. if available, left-most audio source will be used first)
-for s in "$CMUS" "$ITUNES" "$SPOTIFY" "$PIANOBAR"; do
+for s in "$CMUS" "$ITUNES" "$MUSIC" "$SPOTIFY" "$PIANOBAR"; do
   if [[ $s = "$CMUS" && $cmus_pid ]]; then
     current_source="$CMUS"
     break
   elif [[ $s = "$ITUNES" && $itunes_pid ]]; then
     current_source="$ITUNES"
+    break
+  elif [[ $s = "$MUSIC" && $music_pid ]]; then
+    current_source="$MUSIC"
     break
   elif [[ $s = "$SPOTIFY" && $spotify_pid ]]; then
     current_source="$SPOTIFY"
@@ -119,6 +128,10 @@ function playing_info
     track=$(osascript -e 'try' -e 'tell application "iTunes" to name of current track as string' -e 'on error errText' -e '""' -e 'end try');
     artist=$(osascript -e 'try' -e 'tell application "iTunes" to artist of current track as string' -e 'on error errText' -e '""' -e 'end try');
     album=$(osascript -e 'try' -e 'tell application "iTunes" to album of current track as string' -e 'on error errText' -e '""' -e 'end try');
+  elif [[ $current_source = "$MUSIC" ]]; then
+    track=$(osascript -e 'try' -e 'tell application "Music" to name of current track as string' -e 'on error errText' -e '""' -e 'end try');
+    artist=$(osascript -e 'try' -e 'tell application "Music" to artist of current track as string' -e 'on error errText' -e '""' -e 'end try');
+    album=$(osascript -e 'try' -e 'tell application "Music" to album of current track as string' -e 'on error errText' -e '""' -e 'end try');
   elif [[ $current_source = "$PIANOBAR" ]]; then
     # First check if 'playing' file exists
     if [ -f "$pianobar_playingfile" ]; then

--- a/Music/music-controls-like.10s.sh
+++ b/Music/music-controls-like.10s.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Like the current track in iTunes or pianobar.
+# Like the current track in iTunes, Music or pianobar.
 #
 # Special thanks to Google for providing the open-source icons: https://github.com/google/material-design-icons
 # and to mcchrish and alekseysotnikov for their helpful existing BitBar scripts
@@ -10,7 +10,7 @@
 # <bitbar.version>v1.0</bitbar.version>
 # <bitbar.author>Sebastián Barschkis</bitbar.author>
 # <bitbar.author.github>sebbas</bitbar.author.github>
-# <bitbar.desc>Likes the current track in iTunes or pianobar.</bitbar.desc>
+# <bitbar.desc>Likes the current track in iTunes, Music or pianobar.</bitbar.desc>
 # <bitbar.image>https://raw.githubusercontent.com/sebbas/music-controls-bitbar/master/music-controls-screenshot.png</bitbar.image>
 # <bitbar.abouturl>http://github.com/sebbas/music-controls-bitbar</bitbar.abouturl>
 
@@ -22,6 +22,7 @@ pianobar_ctlfile="$HOME/.config/pianobar/ctl"
 NONE="none"
 CMUS="cmus"
 ITUNES="iTunes"
+MUSIC="Music"
 SPOTIFY="Spotify"
 PIANOBAR="pianobar"
 
@@ -31,6 +32,10 @@ like_icon_dark="iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAAAXNSR0IArs4c6QAA
 # Trigger like track in music application
 if [[ "$1" = 'itunes_like' ]]; then
   osascript -e 'tell application "iTunes"' -e 'if loved of current track is true then' -e 'set loved of current track to false' -e 'else' -e 'set loved of current track to true' -e 'end if' -e 'end tell'
+  exit
+fi
+if [[ "$1" = 'music_like' ]]; then
+  osascript -e 'tell application "Music"' -e 'if loved of current track is true then' -e 'set loved of current track to false' -e 'else' -e 'set loved of current track to true' -e 'end if' -e 'end tell'
   exit
 fi
 if [[ "$1" = 'pianobar_like' ]]; then
@@ -49,18 +54,22 @@ current_source="$NONE"
 # Get pid of music apps to see if they are currently running
 cmus_pid=$(pgrep -x "$CMUS")
 itunes_pid=$(pgrep -x "$ITUNES")
+music_pid=$(pgrep -x "$MUSIC")
 spotify_pid=$(pgrep -x "$SPOTIFY")
 pianobar_pid=$(pgrep -x "$PIANOBAR")
 
 # Keep track of music source
 # Reorder items in for-loop to your liking to change order of precendece
 # (i.e. if available, left-most audio source will be used first)
-for s in "$CMUS" "$ITUNES" "$SPOTIFY" "$PIANOBAR"; do
+for s in "$CMUS" "$ITUNES" "$MUSIC" "$SPOTIFY" "$PIANOBAR"; do
   if [[ $s = "$CMUS" && $cmus_pid ]]; then
     # cmus does not support likes
     exit
   elif [[ $s = "$ITUNES" && $itunes_pid ]]; then
     current_source="$ITUNES"
+    break
+  elif [[ $s = "$MUSIC" && $music_pid ]]; then
+    current_source="$MUSIC"
     break
   elif [[ $s = "$SPOTIFY" && $spotify_pid ]]; then
     # spotify (applescript) api does not support likes
@@ -86,6 +95,8 @@ fi
 # Trigger like track in correct music app
 if [[ $current_source = "$ITUNES" ]]; then
   echo " | image=$icon bash='$0' param1='itunes_like' terminal=false refresh=false"
+elif [[ $current_source = "$MUSIC" ]]; then
+  echo " | image=$icon bash='$0' param1='music_like' terminal=false refresh=false"
 elif [[ $current_source = "$PIANOBAR" ]]; then
   echo " | image=$icon bash='$0' param1='pianobar_like' terminal=false refresh=false"
 fi

--- a/Music/music-controls-next.10s.sh
+++ b/Music/music-controls-next.10s.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Plays the next track in cmus, iTunes, Spotify or pianobar.
+# Plays the next track in cmus, iTunes, Music, Spotify or pianobar.
 #
 # Special thanks to Google for providing the open-source icons: https://github.com/google/material-design-icons
 # and to mcchrish and alekseysotnikov for their helpful existing BitBar scripts
@@ -10,7 +10,7 @@
 # <bitbar.version>v1.0</bitbar.version>
 # <bitbar.author>Sebastián Barschkis</bitbar.author>
 # <bitbar.author.github>sebbas</bitbar.author.github>
-# <bitbar.desc>Plays the next track in cmus, iTunes, Spotify or pianobar.</bitbar.desc>
+# <bitbar.desc>Plays the next track in cmus, iTunes, Music, Spotify or pianobar.</bitbar.desc>
 # <bitbar.image>https://raw.githubusercontent.com/sebbas/music-controls-bitbar/master/music-controls-screenshot.png</bitbar.image>
 # <bitbar.abouturl>http://github.com/sebbas/music-controls-bitbar</bitbar.abouturl>
 
@@ -22,6 +22,7 @@ pianobar_ctlfile="$HOME/.config/pianobar/ctl"
 NONE="none"
 CMUS="cmus"
 ITUNES="iTunes"
+MUSIC="Music"
 SPOTIFY="Spotify"
 PIANOBAR="pianobar"
 
@@ -35,6 +36,10 @@ if [[ "$1" = 'cmus_next' ]]; then
 fi
 if [[ "$1" = 'itunes_next' ]]; then
   osascript -e 'tell application "iTunes" to next track'
+  exit
+fi
+if [[ "$1" = 'music_next' ]]; then
+  osascript -e 'tell application "Music" to next track'
   exit
 fi
 if [[ "$1" = 'spotify_next' ]]; then
@@ -57,18 +62,22 @@ current_source="$NONE"
 # Get pid of music apps to see if they are currently running
 cmus_pid=$(pgrep -x "$CMUS")
 itunes_pid=$(pgrep -x "$ITUNES")
+music_pid=$(pgrep -x "$MUSIC")
 spotify_pid=$(pgrep -x "$SPOTIFY")
 pianobar_pid=$(pgrep -x "$PIANOBAR")
 
 # Keep track of music source
 # Reorder items in for-loop to your liking to change order of precendece
 # (i.e. if available, left-most audio source will be used first)
-for s in "$CMUS" "$ITUNES" "$SPOTIFY" "$PIANOBAR"; do
+for s in "$CMUS" "$ITUNES" "$MUSIC" "$SPOTIFY" "$PIANOBAR"; do
   if [[ $s = "$CMUS" && $cmus_pid ]]; then
     current_source="$CMUS"
     break
   elif [[ $s = "$ITUNES" && $itunes_pid ]]; then
     current_source="$ITUNES"
+    break
+  elif [[ $s = "$MUSIC" && $music_pid ]]; then
+    current_source="$MUSIC"
     break
   elif [[ $s = "$SPOTIFY" && $spotify_pid ]]; then
     current_source="$SPOTIFY"
@@ -96,6 +105,8 @@ if [[ $current_source = "$CMUS" ]]; then
   echo " | image=$icon bash='$0' param1='cmus_next' terminal=false refresh=false"
 elif [[ $current_source = "$ITUNES" ]]; then
   echo " | image=$icon bash='$0' param1='itunes_next' terminal=false refresh=false"
+elif [[ $current_source = "$MUSIC" ]]; then
+  echo " | image=$icon bash='$0' param1='music_next' terminal=false refresh=false"
 elif [[ $current_source = "$SPOTIFY" ]]; then
   echo " | image=$icon bash='$0' param1='spotify_next' terminal=false refresh=false"
 elif [[ $current_source = "$PIANOBAR" ]]; then

--- a/Music/music-controls-playpause.10s.sh
+++ b/Music/music-controls-playpause.10s.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Plays / pauses the current track in cmus, iTunes, Spotify or pianobar.
+# Plays / pauses the current track in cmus, iTunes, Music, Spotify or pianobar.
 #
 # Special thanks to Google for providing the open-source icons: https://github.com/google/material-design-icons
 # and to mcchrish and alekseysotnikov for their helpful existing BitBar scripts
@@ -10,7 +10,7 @@
 # <bitbar.version>v1.0</bitbar.version>
 # <bitbar.author>Sebastián Barschkis</bitbar.author>
 # <bitbar.author.github>sebbas</bitbar.author.github>
-# <bitbar.desc>Plays / pauses the current track in cmus, iTunes, Spotify or pianobar.</bitbar.desc>
+# <bitbar.desc>Plays / pauses the current track in cmus, iTunes, Music, Spotify or pianobar.</bitbar.desc>
 # <bitbar.image>https://raw.githubusercontent.com/sebbas/music-controls-bitbar/master/music-controls-screenshot.png</bitbar.image>
 # <bitbar.abouturl>http://github.com/sebbas/music-controls-bitbar</bitbar.abouturl>
 
@@ -22,6 +22,7 @@ pianobar_ctlfile="$HOME/.config/pianobar/ctl"
 NONE="none"
 CMUS="cmus"
 ITUNES="iTunes"
+MUSIC="Music"
 SPOTIFY="Spotify"
 PIANOBAR="pianobar"
 
@@ -35,6 +36,10 @@ if [[ "$1" = 'cmus_playpause' ]]; then
 fi
 if [[ "$1" = 'itunes_playpause' ]]; then
   osascript -e 'tell application "iTunes" to playpause'
+  exit
+fi
+if [[ "$1" = 'music_playpause' ]]; then
+  osascript -e 'tell application "Music" to playpause'
   exit
 fi
 if [[ "$1" = 'spotify_playpause' ]]; then
@@ -57,18 +62,22 @@ current_source="$NONE"
 # Get pid of music apps to see if they are currently running
 cmus_pid=$(pgrep -x "$CMUS")
 itunes_pid=$(pgrep -x "$ITUNES")
+music_pid=$(pgrep -x "$MUSIC")
 spotify_pid=$(pgrep -x "$SPOTIFY")
 pianobar_pid=$(pgrep -x "$PIANOBAR")
 
 # Keep track of music source
 # Reorder items in for -loop to your liking to change order of precendece
 # (i.e. if available, left-most audio source will be used first)
-for s in "$CMUS" "$ITUNES" "$SPOTIFY" "$PIANOBAR"; do
+for s in "$CMUS" "$ITUNES" "$MUSIC" "$SPOTIFY" "$PIANOBAR"; do
   if [[ $s = "$CMUS" && $cmus_pid ]]; then
     current_source="$CMUS"
     break
   elif [[ $s = "$ITUNES" && $itunes_pid ]]; then
     current_source="$ITUNES"
+    break
+  elif [[ $s = "$MUSIC" && $music_pid ]]; then
+    current_source="$MUSIC"
     break
   elif [[ $s = "$SPOTIFY" && $spotify_pid ]]; then
     current_source="$SPOTIFY"
@@ -96,6 +105,8 @@ if [[ $current_source = "$CMUS" ]]; then
   echo " | image=$icon bash='$0' param1='cmus_playpause' terminal=false refresh=false"
 elif [[ $current_source = "$ITUNES" ]]; then
   echo " | image=$icon bash='$0' param1='itunes_playpause' terminal=false refresh=false"
+elif [[ $current_source = "$MUSIC" ]]; then
+  echo " | image=$icon bash='$0' param1='music_playpause' terminal=false refresh=false"
 elif [[ $current_source = "$SPOTIFY" ]]; then
   echo " | image=$icon bash='$0' param1='spotify_playpause' terminal=false refresh=false"
 elif [[ $current_source = "$PIANOBAR" ]]; then

--- a/Music/music-controls-previous.10s.sh
+++ b/Music/music-controls-previous.10s.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Plays the previous track in cmus, iTunes or Spotify.
+# Plays the previous track in cmus, iTunes Music, or Spotify.
 #
 # Special thanks to Google for providing the open-source icons: https://github.com/google/material-design-icons
 # and to mcchrish and alekseysotnikov for their helpful existing BitBar scripts
@@ -10,7 +10,7 @@
 # <bitbar.version>v1.0</bitbar.version>
 # <bitbar.author>Sebastián Barschkis</bitbar.author>
 # <bitbar.author.github>sebbas</bitbar.author.github>
-# <bitbar.desc>Plays the previous track in cmus, iTunes or Spotify.</bitbar.desc>
+# <bitbar.desc>Plays the previous track in cmus, iTunes, Music or Spotify.</bitbar.desc>
 # <bitbar.image>https://raw.githubusercontent.com/sebbas/music-controls-bitbar/master/music-controls-screenshot.png</bitbar.image>
 # <bitbar.abouturl>http://github.com/sebbas/music-controls-bitbar</bitbar.abouturl>
 
@@ -20,6 +20,7 @@ export LC_CTYPE="UTF-8"
 NONE="none"
 CMUS="cmus"
 ITUNES="iTunes"
+MUSIC="Music"
 SPOTIFY="Spotify"
 PIANOBAR="pianobar"
 
@@ -35,6 +36,10 @@ if [[ "$1" = 'itunes_prev' ]]; then
   osascript -e 'tell application "iTunes" to previous track'
   exit
 fi
+if [[ "$1" = 'music_prev' ]]; then
+  osascript -e 'tell application "Music" to previous track'
+  exit
+fi
 if [[ "$1" = 'spotify_prev' ]]; then
   osascript -e 'tell application "Spotify" to previous track'
   exit
@@ -46,18 +51,22 @@ current_source="$NONE"
 # Get pid of music apps to see if they are currently running
 cmus_pid=$(pgrep -x "$CMUS")
 itunes_pid=$(pgrep -x "$ITUNES")
+music_pid=$(pgrep -x "$MUSIC")
 spotify_pid=$(pgrep -x "$SPOTIFY")
 pianobar_pid=$(pgrep -x "$PIANOBAR")
 
 # Keep track of music source
 # Reorder items in for -loop to your liking to change order of precendece
 # (i.e. if available, left-most audio source will be used first)
-for s in "$CMUS" "$ITUNES" "$SPOTIFY" "$PIANOBAR"; do
+for s in "$CMUS" "$ITUNES" "$MUSIC" "$SPOTIFY" "$PIANOBAR"; do
   if [[ $s = "$CMUS" && $cmus_pid ]]; then
     current_source="$CMUS"
     break
   elif [[ $s = "$ITUNES" && $itunes_pid ]]; then
     current_source="$ITUNES"
+    break
+  elif [[ $s = "$MUSIC" && $music_pid ]]; then
+    current_source="$MUSIC"
     break
   elif [[ $s = "$SPOTIFY" && $spotify_pid ]]; then
     current_source="$SPOTIFY"
@@ -85,6 +94,8 @@ if [[ $current_source = "$CMUS" ]]; then
   echo " | image=$icon bash='$0' param1='cmus_prev' terminal=false refresh=false"
 elif [[ $current_source = "$ITUNES" ]]; then
   echo " | image=$icon bash='$0' param1='itunes_prev' terminal=false refresh=false"
+elif [[ $current_source = "$MUSIC" ]]; then
+  echo " | image=$icon bash='$0' param1='music_prev' terminal=false refresh=false"
 elif [[ $current_source = "$SPOTIFY" ]]; then
   echo " | image=$icon bash='$0' param1='spotify_prev' terminal=false refresh=false"
 fi


### PR DESCRIPTION
Duplicated the iTunes references for all `music-controls-*.sh` plugins.

Tested and confirmed all are working in macOS Catalina (10.15.3)