### PR TITLE
add no_annotations=1 to OpenCage API call

### DIFF
--- a/Weather/DarkSky/weather.15m.py
+++ b/Weather/DarkSky/weather.15m.py
@@ -67,7 +67,7 @@ def auto_loc_lookup():
 
 def reverse_latlong_lookup(loc):
   try:
-    location_url = 'https://api.opencagedata.com/geocode/v1/json?q=' + loc + '&key=' + geo_api_key + '&language=en&pretty=1'
+    location_url = 'https://api.opencagedata.com/geocode/v1/json?q=' + loc + '&key=' + geo_api_key + '&language=en&no_annotations=1&pretty=1'
     location = json.load(urllib2.urlopen(location_url))
     if 'results' in location:
       return location['results'][0]['formatted'].encode('UTF-8')


### PR DESCRIPTION
As per OpenCage best practices https://opencagedata.com/api#bestpractices
add no_annotations=1 since this script doesn't use any of the information in the annotations.

That said, might be interesting to use OpenCage's "sun" annotation which is the time of sunset and sunrise at that location:
https://opencagedata.com/api#sun