### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ osx_image: xcode11.2
 
 before_install:
   - brew outdated python || brew upgrade python
-  - pip2 install pyflakes
   - pip3 install pyflakes
   - gem install rubocop
   - brew install shellcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ osx_image: xcode11.2
 
 before_install:
   - brew outdated python || brew upgrade python
-  - brew outdated python@2 || brew upgrade python@2
   - pip2 install pyflakes
   - pip3 install pyflakes
   - gem install rubocop


### PR DESCRIPTION
There is no @2 version of python in the homebrew mainline anymore. If this is still needed, we would need to install it another way.