### PR TITLE
Remove docker-machine dependency

### DIFF
--- a/Dev/Docker/docker-status.1m.sh
+++ b/Dev/Docker/docker-status.1m.sh
@@ -6,7 +6,7 @@
 # <bitbar.author.github>manojlds</bitbar.author.github>
 # <bitbar.image>https://cloud.githubusercontent.com/assets/191378/12255368/1e671b32-b919-11e5-8166-6d975396f408.png</bitbar.image>
 # <bitbar.desc>Displays the status of docker machines and running containers</bitbar.desc>
-# <bitbar.dependencies>shell,docker,docker-machine</bitbar.dependencies>
+# <bitbar.dependencies>shell,docker</bitbar.dependencies>
 #
 # Docker status plugin
 # by Manoj Mahalingam (@manojlds)
@@ -36,10 +36,15 @@ function containers() {
     done
   fi
 }
-
-DOCKER_MACHINES="$(docker-machine ls -q)"
-DLITE="$(which dlite)"
-DOCKER_NATIVE="$(which docker)"
+if command -v docker-machine; then
+    DOCKER_MACHINES="$(docker-machine ls -q)"
+fi
+if command -v dlite; then
+    DLITE="$(which dlite)"
+fi
+if command -v docker; then
+    DOCKER_NATIVE="$(which docker)"
+fi
 
 if test -z "$DOCKER_MACHINES" && test -z "$DLITE" && test -z "$DOCKER_NATIVE"; then
   echo "No docker machine, dlite or docker native found"

--- a/Dev/Docker/docker-status.1m.sh
+++ b/Dev/Docker/docker-status.1m.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # <bitbar.title>Docker Status</bitbar.title>
-# <bitbar.version>v1.1</bitbar.version>
+# <bitbar.version>v1.2</bitbar.version>
 # <bitbar.author>Manoj Mahalingam</bitbar.author>
 # <bitbar.author.github>manojlds</bitbar.author.github>
 # <bitbar.image>https://cloud.githubusercontent.com/assets/191378/12255368/1e671b32-b919-11e5-8166-6d975396f408.png</bitbar.image>


### PR DESCRIPTION
Since Docker for Mac is [no longer packaged with `docker-machine`](https://github.com/docker/for-mac/issues/4208#issuecomment-576811681), docker-machine should not be a dependency; currently an up-to-date install produces an error for `docker-machine: command not found`. 

This removes the docker-machine requirement by preventing the variables from being set if the commands don't exist. This way the [empty string conditional](https://github.com/matryer/bitbar-plugins/blob/7bddc2f1692a80c774535f6aad18d2c2f45c2403/Dev/Docker/docker-status.1m.sh#L49) works as intended, and the `[ -n ... ]` tests don't return true when they shouldn't.