### PR TITLE
Spotify Now Playing (via spotctl): ignore errors

### DIFF
--- a/Music/spotctl.10s.sh
+++ b/Music/spotctl.10s.sh
@@ -33,7 +33,7 @@ case "$1" in
     exit
 esac
 
-state=$(spotctl status | sed -n 1p | grep -o playing || echo paused)
+state=$(spotctl status 2> /dev/null | sed -n 1p | grep -o playing || echo paused)
 
 if [ "$state" = "playing" ]; then
   status=$(spotctl status)


### PR DESCRIPTION
Sometimes spotctl gets a weird response from Spotify even though everything is fine, this can just be ignored.