### PR TITLE
Issue #1468 - Now Playing opens Podcasts in Catalina

### DIFF
--- a/Music/nowplaying.5s.sh
+++ b/Music/nowplaying.5s.sh
@@ -10,9 +10,15 @@
 # <bitbar.abouturl></bitbar.abouturl>
 
 # first, determine if there's an app that's playing or paused
-apps=(iTunes Music Spotify Vox)
+apps=(Music Spotify Vox)
 playing=""
 paused=""
+
+# Determine if we are running a pre-Catalina OS X version and adjust the apps accordingly.
+osx_ver_before_catalina=$(sw_vers -productVersion | grep -E "10\.\d[0-4]+\..*")
+if [ -n "$osx_ver_before_catalina" ]; then
+  apps=(iTunes Spotify Vox)
+fi
 
 for i in "${apps[@]}"; do
 	# is the app running?
@@ -87,7 +93,7 @@ else
 		track_query="track"
 		artist_query="artist"
 	fi
-	
+
 	# output the track and artist
 	track=$(osascript -e "tell application \"$app\" to $track_query")
 	artist=$(osascript -e "tell application \"$app\" to $artist_query")


### PR DESCRIPTION
Assume we are on Catalina or higher to start and not show an iTunes menu item. It appears "iTunes" is an alias under the hood for the new "Podcasts" app. Detect if we are on a pre-Catalina version of OS X and adjust the menu to have iTunes app instead of Music app.

Tried having "Podcasts" in the menu, but the app overall does not behave in the same way as the others. The check for the player state throws an error. Rather than dive down that rabbit hole, fix this bug and address Podcasts some other day.