### PR TITLE
Deduplicate hosts in ssh-tunnel

### DIFF
--- a/Network/ssh-tunnel.1s.sh
+++ b/Network/ssh-tunnel.1s.sh
@@ -31,7 +31,7 @@ function hosts() {
         $1 == "DynamicForward" || $1 == "LocalForward" {
             print host;
         }
-    ' "$1"
+    ' "$1" | uniq
 }
 
 for h in $(hosts ~/.ssh/config); do


### PR DESCRIPTION
The ssh-tunnel plugin prints a host every time it finds a line with DynamicForward or LocalForward. This change condenses consecutive duplicate hosts to ensure only one host is displayed in the menu, even if that host configuration has multiple forwards configured.

For example, the following SSH_CONFIG would produce two "example.com" menu items:
```
Host example.com
  LocalForward 6443 127.0.0.1:6443
  DynamicForward 127.0.0.1:3128
```

With this change, it only produces one "example.com" menu item.