### PR TITLE
Add plugin to show Kubernetes pods running in default namespace.

### DIFF
--- a/Dev/Kubernetes/k-get-pods.30s.sh
+++ b/Dev/Kubernetes/k-get-pods.30s.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# <bitbar.title>List running Kubernetes pods (default namespace)</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Robert Prince</bitbar.author>
+# <bitbar.author.github>robertp</bitbar.author.github>
+# <bitbar.desc>Simple that shows running Kubernetes pods; it's just output from 'kubectl get pods' with a font specified. It assumes you have installed kubectl using brew.</bitbar.desc>
+# <bitbar.dependencies>brew,kubectl</bitbar.dependencies>
+
+export PATH=/usr/local/bin:"${PATH}"
+
+echo "k8s pods"
+echo "---"
+kubectl get pods | while read -r line; do echo "${line} | font=Menlo"; done


### PR DESCRIPTION
Signed-off-by: Robert Prince <robert@robertprince.net>