### PR TITLE
Issue #719 - Simple RSS reader throws error if feed returns empty string.

### DIFF
--- a/Web/RSSReader/rss.15m.php
+++ b/Web/RSSReader/rss.15m.php
@@ -80,6 +80,12 @@ class RSSParser
         $this->loadLogData();
 
         $feed_data = @file_get_contents(FEED_URL);
+
+        if ($feed_data === '') {
+            $this->title = 'No new items at this time.';
+            return;
+        }
+
         $this->feed = new DOMDocument();
         $this->feed->loadXML($feed_data);
 


### PR DESCRIPTION
This work checks if the feed data returned is an empty string. If it is, the title will be set to `No new items at this time.` and will not attempt to process the feed.