### PR TITLE
 Issue #938 - Fix display of internal IP address

### DIFF
--- a/Network/internal-ip.1h.sh
+++ b/Network/internal-ip.1h.sh
@@ -6,9 +6,16 @@
 # <bitbar.desc>Gets the current internal IP address, and shows more information in the details.</bitbar.desc>
 # <bitbar.version>1.0</bitbar.version>
 
-ACTIVE_ADAPTER=$(ifconfig | grep ^en | head -n1 | cut -d: -f1)
-ipconfig getifaddr "$ACTIVE_ADAPTER";
-echo "---"
-echo "(Internal IP address)"
-echo "---"
-ifconfig "$ACTIVE_ADAPTER";
+ifconfig | grep -e "^en" | sort -u | while read line ; do
+    ACTIVE_ADAPTER=$(echo $line | awk -F: '{print $1}')
+    INTERNAL_IP_ADDRESS=$(ifconfig $ACTIVE_ADAPTER | grep "inet " | awk '{print $2}')
+    if [ -n "$INTERNAL_IP_ADDRESS" ]; then
+        echo $INTERNAL_IP_ADDRESS
+        echo "---"
+        echo "(Internal IP address)"
+        echo "---"
+        ifconfig ${ACTIVE_ADAPTER}
+
+        break
+    fi
+done


### PR DESCRIPTION
 This work iterates over all `en` prefixed interfaces / adapters to find the internal IP address of the machine. It then displays the details of the interface / adapter tied to the IP address.