### PR TITLE
Fix 'no screens' state in screen.2m.sh plugin

### DIFF
--- a/Tools/screen.2m.sh
+++ b/Tools/screen.2m.sh
@@ -14,8 +14,8 @@ PATH="/usr/local/bin:$PATH" SCREEN_COMMAND=$(command -v screen)
 echo "💻"
 echo '---'
 SCREENS=$(${SCREEN_COMMAND} -list | grep -o '\s*.*\s*(.*)')
-if [[ -z ${SCREENS} ]]; then
-  echo "no screens"
+if [[ -z ${SCREENS} ]] || [[ ${SCREENS} =~ ^.*empty.*$ ]]; then
+  echo "new screen session | refresh=true bash=${SCREEN_COMMAND}";
 else
   (
     IFS=$'\n'; for LINE in $(screen -list); do


### PR DESCRIPTION
The conditional that checks for a 'no screens' state was erroneously only checking for a lack of return from 'screen -list'.  A successful 'screen -list' contains an 'is empty' message which prevented the
display.

This commit also adds an action to create a screen session if none currently exist.  So here we change the 'no screen' message to 'new screen session'.

<img width="248" alt="Screen Shot 2020-10-03 at 3 24 43 PM" src="https://user-images.githubusercontent.com/2664155/95001111-93503680-058c-11eb-9784-6bed8e10cfde.png">
