### PR TITLE
Update dnscrypt-proxy-switcher to support macOS 11

### DIFF
--- a/Network/dnscrypt-proxy-switcher.10s.sh
+++ b/Network/dnscrypt-proxy-switcher.10s.sh
@@ -46,8 +46,11 @@ classic)
 esac
 
 osversion=$(sw_vers -productVersion)
-osmajor=$(echo "$osversion" | awk -F. '{print $2}')
-[ "$osmajor" -lt 7 ] && exit 1
+osmajor=$(echo "$osversion" | awk -F. '{print $1}')
+osminor=$(echo "$osversion" | awk -F. '{print $2}')
+ospatch=$(echo "$osversion" | awk -F. '{print $3}')
+[[ "$osmajor" -eq 10 && "$osminor" -lt 7 ]] && exit 14
+[ "$osmajor" -lt 10 ] && exit 15
 
 get_current_service() {
 	services=$(networksetup -listnetworkserviceorder | grep -F 'Hardware Port')
@@ -111,33 +114,39 @@ get_current_resolvers() {
 }
 
 flush_dns_cache() {
-	if [ "$osmajor" -le 8 ]; then
-		killall -HUP mDNSResponder 2>/dev/null
-	elif [ "$osmajor" = 9 ]; then
-		dscacheutil -flushcache 2>/dev/null
-		killall -HUP mDNSResponder 2>/dev/null
-	elif [ "$osmajor" = 10 ]; then
-		osminor=$(echo "$osversion" | awk -F. '{print $3}')
-		if [ "$osminor" -le 3 ]; then
-			discoveryutil mdnsflushcache 2>/dev/null
-			discoveryutil udnsflushcaches 2>/dev/null
-		else
+	if [ "$osmajor" -eq 10 ]; then
+		if [ "$osminor" -le 8 ]; then
+			killall -HUP mDNSResponder 2>/dev/null
+		elif [ "$osminor" = 9 ]; then
 			dscacheutil -flushcache 2>/dev/null
 			killall -HUP mDNSResponder 2>/dev/null
-		fi
-	elif [ "$osmajor" = 11 ]; then
-		dscacheutil -flushcache 2>/dev/null
-		killall -HUP mDNSResponder 2>/dev/null
-	elif [ "$osmajor" = 12 ]; then
-		osminor=$(echo "$osversion" | awk -F. '{print $3}')
-		if [ "$osminor" -le 2 ]; then
+		elif [ "$osminor" = 10 ]; then
+			if [ "$ospatch" -le 3 ]; then
+				discoveryutil mdnsflushcache 2>/dev/null
+				discoveryutil udnsflushcaches 2>/dev/null
+			else
+				dscacheutil -flushcache 2>/dev/null
+				killall -HUP mDNSResponder 2>/dev/null
+			fi
+		elif [ "$osminor" = 11 ]; then
+			dscacheutil -flushcache 2>/dev/null
+			killall -HUP mDNSResponder 2>/dev/null
+		elif [ "$osminor" = 12 ]; then
+			if [ "$ospatch" -le 2 ]; then
+				killall -HUP mDNSResponder 2>/dev/null
+			else
+				killall -HUP mDNSResponder 2>/dev/null
+				killall mDNSResponderHelper 2>/dev/null
+				dscacheutil -flushcache 2>/dev/null
+			fi
+		elif [ "$osminor" = 15 ]; then
+			dscacheutil -flushcache 2>/dev/null
 			killall -HUP mDNSResponder 2>/dev/null
 		else
 			killall -HUP mDNSResponder 2>/dev/null
-			killall mDNSResponderHelper 2>/dev/null
-			dscacheutil -flushcache 2>/dev/null
 		fi
-	else
+	elif [ "$osmajor" -eq 11 ]; then
+		dscacheutil -flushcache 2>/dev/null
 		killall -HUP mDNSResponder 2>/dev/null
 	fi
 }


### PR DESCRIPTION
The way this script was checking the macOS version was flawed—it assumed that the major version was 10, and it also called the second part of the version number the "major" version, which was incorrect.

Based on my research, the correct way to reset the DNS cache on 10.15 and 11.0 is the same, and it includes `dscacheutil -flushcache`. But the script didn't previously include that command for 10.15, it fell back to the default on 10.13 and higher, only killing `mDNSResponder`. That's still the command used for 10.13 and 10.14.

I also changed the version number checks to return unique values so it's easier to troubleshoot.
