### PR TITLE
Fix GitHub contributions regex after markup change

### DIFF
--- a/Dev/GitHub/github-contribution.10m.rb
+++ b/Dev/GitHub/github-contribution.10m.rb
@@ -79,7 +79,7 @@ module BitBar
     ConfigurationError = Class.new(StandardError)
 
     class Contribution < Struct.new(:username, :contributed_on, :count)
-      RE_CONTRIBUTION = %r|<rect class="day" .+ data-count="(\d+)" data-date="(\d\d\d\d-\d\d-\d\d)"/>|
+      RE_CONTRIBUTION = %r|<rect .+class="ContributionCalendar-day" .+ data-count="(\d+)" data-date="(\d\d\d\d-\d\d-\d\d)"|
       def self.find_all_by(username:)
         [].tap do |contributions|
           today = Date.parse(DateTime.now.to_s).to_s
@@ -87,6 +87,7 @@ module BitBar
           html = URI.send(:open, "https://github.com/users/#{username}/contributions?to=#{today}#year-link-#{year}") { |f| f.read };
           html.scan(RE_CONTRIBUTION) do |count, date|
             contributions << Contribution.new(username, Date.parse(date), count.to_i)
+            break if Date.parse(date) == Date.parse(DateTime.now.to_s)
           end
         end
       end


### PR DESCRIPTION
GitHub seems to have changed the markup for their contributions "partial", so the regex does not match anymore.
I've changed the regex slightly, and also had to add a break to the scanning loop as it was continuing to the end of the year - I think maybe they've removed a feature of the endpoint so that it doesn't stop on the date you give it.