### PR TITLE
Show Time in Most of the Standard timezones.

### DIFF
--- a/Time/timezone-display.30s.py
+++ b/Time/timezone-display.30s.py
@@ -6,7 +6,7 @@
 # <xbar.author>Ameya Bapat</xbar.author>
 # <xbar.author.github>ameyabap</xbar.author.github>
 # <xbar.desc>Display current time in multiple timezones with easy timezone selection</xbar.desc>
-# <xbar.image>https://raw.githubusercontent.com/ameyabap/resources/refs/heads/main/960px-World_Time_Zones_Map.svg.png</xbar.image>
+# <xbar.image>https://raw.githubusercontent.com/ameyabap/resources/refs/heads/main/xbar-plugin/timezone/Screenshot%202025-07-31%20at%2011.00.37.png</xbar.image>
 # <xbar.dependencies>python3</xbar.dependencies>
 # <xbar.abouturl>https://github.com/ameyabap/resources/blob/main/timezone-xbarapp-plugin.md</xbar.abouturl>
 


### PR DESCRIPTION
# Timezone Display
<img width="378" height="434" alt="Screenshot 2025-07-31 at 11 18 51" src="https://github.com/user-attachments/assets/27b4fc55-6c0e-4319-84cd-be488f7f7705" />
<img width="526" height="484" alt="Screenshot 2025-07-31 at 11 18 27" src="https://github.com/user-attachments/assets/d1068255-6551-4dae-ba88-0824380f0b7c" />
<img width="549" height="213" alt="Screenshot 2025-07-31 at 11 18 41" src="https://github.com/user-attachments/assets/4215473b-3f9e-40ac-9487-16f570a9c337" />

xbar plugin that displays time across multiple timezones with DST support.

## Features

- Shows 16 major timezones
- Click to switch primary timezone in menu bar
- Automatic daylight saving time
- Updates every 30 seconds

## Installation

1. Download `timezone-display.30s.py`
2. Make executable: `chmod +x timezone-display.30s.py`
3. Move to xbar plugins folder
4. Refresh xbar

## Usage

- Menu bar shows selected timezone (defaults to UTC)
- Click menu bar to see all timezones
- Click any timezone to set as primary

## Supported Timezones

UTC, New York, Chicago, Denver, Los Angeles, Toronto, Vancouver, São Paulo, London, Paris, Berlin, Tokyo, Shanghai, Mumbai/Delhi, Dubai, Sydney, Melbourne, Auckland