### PR TITLE
Add plugin for AWS Cloudformation status

### DIFF
--- a/AWS/cloudformation-status.30s.py
+++ b/AWS/cloudformation-status.30s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /Users/sergio.pena/.asdf/installs/python/3.13.2/bin/python
+#!/usr/bin/env -S PATH="${PATH}:/opt/homebrew/bin:/usr/local/bin" python3
 
 # -*- coding: utf-8 -*-
 


### PR DESCRIPTION
Plugin to monitor AWS cloudformation stacks status.
It return a list of the stacks matching the configuration variables, info about last update time, last updated status and a link to the AWS console for that stack