### PR TITLE
Fix GitHub Notifications plugin to support modern PAT tokens

### DIFF
--- a/Dev/GitHub/notifications.30s.py
+++ b/Dev/GitHub/notifications.30s.py
@@ -138,9 +138,9 @@ def format_notification(notification):
     # Try to hack a web-viewable URL if the last check failed
     if formatted["href"]:
         formatted["href"] = re.sub(
-            "api\.|api/v3/|repos/",
+            r"api\.|api/v3/|repos/",
             "",
-            re.sub("(pull|commit)s", r"\1", formatted["href"]),
+            re.sub(r"(pull|commit)s", r"\1", formatted["href"]),
         )
     if type == "PullRequest":
         if typejson and typejson["merged"]:
@@ -220,8 +220,8 @@ if len(sys.argv) > 1:
         make_github_request(url=url, method="PATCH", data={}, enterprise=enterprise)
 
 else:
-    is_github_defined = len(github_api_key) == 40
-    is_github_enterprise_defined = len(enterprise_api_key) == 40
+    is_github_defined = bool(github_api_key)
+    is_github_enterprise_defined = bool(enterprise_api_key)
     github_notifications = (
         get_notifications(enterprise=False) if is_github_defined else []
     )


### PR DESCRIPTION
### Summary
This PR fixes the GitHub Notifications xbar plugin rejecting valid GitHub personal access tokens.

### Background
The plugin currently checks for tokens using `len(token) == 40`, which worked for classic PATs but no longer works with modern GitHub personal access tokens (e.g. `github_pat_...`) that are longer and now recommended by GitHub.

As a result, valid tokens are silently ignored and the plugin shows only a dot.

### Changes
- Accept any non-empty `GITHUB_TOKEN` instead of assuming a fixed length
- Convert regex strings to raw strings to avoid Python `SyntaxWarning`s

### Compatibility
- Classic 40-character tokens continue to work
- No behavior change when no token is set
- No API or UI changes

### Testing
- Tested with classic PAT
- Tested with modern fine-grained `github_pat_...` token
