### PR TITLE
Improvements to Poe and Claude Code plugins

### DIFF
--- a/Dev/claude_code.5m.sh
+++ b/Dev/claude_code.5m.sh
@@ -11,10 +11,12 @@
 #<xbar.var>boolean(VAR_SHOW_7D="false"): Also show 7-day window in title (e.g. 45%/23%).</xbar.var>
 #<xbar.var>boolean(VAR_COLORS="true"): Color-code title at warning (>75%) and critical (>90%) levels.</xbar.var>
 #<xbar.var>boolean(VAR_SHOW_RESET="true"): Show time-until-reset for each window in the dropdown.</xbar.var>
+#<xbar.var>boolean(VAR_SHOW_BARS="true"): Show dynamic dual progress bar icon (5h top, 7d bottom) instead of the Claude logo.</xbar.var>
 
 SHOW_7D="${VAR_SHOW_7D:-false}"
 COLORS="${VAR_COLORS:-true}"
 SHOW_RESET="${VAR_SHOW_RESET:-true}"
+SHOW_BARS="${VAR_SHOW_BARS:-true}"
 
 CLAUDE_ICON="iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAHhlWElmTU0AKgAAAAgABAEaAAUAAAABAAAAPgEbAAUAAAABAAAARgEoAAMAAAABAAIAAIdpAAQAAAABAAAATgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAABKgAwAEAAAAAQAAABIAAAAAqSaGYgAAAAlwSFlzAAALEwAACxMBAJqcGAAAAdJJREFUOBGV0z1IVWEYB3Cv2ZAVlQUpWDnYJqZBREPU1tISBo1OBkEfWBGNQhTR1iwu2hIENdYUVBRBBjXVUEZRYBLah2CD3X5/O/cQ14vRA7/zPO/Hec857zmnqakuqtVqM11U6ob+r2mBQ3zjYu1MdR/3aKv1/TObvI9ffKqdKA+zwOYsIPewv+FiBrbSWky8oU6cKtrX1C+Kuludi3xkaX65oI4WJnlOLx185TUZmyi0yk9JXGf5Puo8zjzfGeACiSPcJu0xErno+vJO6guDu3hAYpwZnvCY3G1ijp76cxu2TTxP7qwWi0WRlzBCP0OMcou2isMWq43wky/MME0vZ9lELaqKjK0m8/ICHjLW4jDPSzrYQDt9JBb/pPKYua+4zyTvmapUKgvy8nCXnWSPpsjj1GJKcZm7TJN4R3vuqAwd6zSGyfdzh2fkEbrIFkQ3A+Tx+lnLbPkdWGSvjnFWcYJOhhjlMD84wCO2c9QjfZaXorlWyLlCFtrNLJcYZAdznCPfzgcmyLe1U24cBrfxhmOZIednvVrUg+rEHvJzH0x/wzB4hisZlNeQ/+p00c7ncpOTDU/+u9Ok8gWoN/KW7FEZ2n9vSdm/YuGkdrJ/K8ZvZcjUYTq3RuAAAAAASUVORK5CYII="
 
@@ -22,7 +24,7 @@ CLAUDE_ICON="iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAHh
 
 show_error() {
   local message="$1"
-  echo "⚠️ | templateImage=${CLAUDE_ICON}"
+  echo "! | templateImage=${CLAUDE_ICON}"
   echo "---"
   echo "${message}"
   echo "---"
@@ -30,13 +32,27 @@ show_error() {
   exit 0
 }
 
-RAW_CREDS="$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)"
+USAGE_CACHE="/tmp/.claude_swiftbar_cache"
+TOKEN_CACHE="/tmp/.claude_swiftbar_token"
+CACHE_TTL=300   # 5 minutes — matches poll interval
+TOKEN_TTL=900   # 15 minutes
 
-if [ -z "$RAW_CREDS" ]; then
-  show_error "No Claude Code credentials found in Keychain. Sign in to Claude Code first."
+# === Get token (cached) ===
+
+TOKEN=""
+if [ -f "$TOKEN_CACHE" ]; then
+  cache_age=$(( $(date -u +%s) - $(stat -f %m "$TOKEN_CACHE" 2>/dev/null || echo 0) ))
+  if [ "$cache_age" -lt "$TOKEN_TTL" ]; then
+    TOKEN="$(cat "$TOKEN_CACHE" 2>/dev/null)"
+  fi
 fi
 
-TOKEN="$(printf '%s' "$RAW_CREDS" | python3 -c "
+if [ -z "$TOKEN" ]; then
+  RAW_CREDS="$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)"
+  if [ -z "$RAW_CREDS" ]; then
+    show_error "No Claude Code credentials found in Keychain. Sign in to Claude Code first."
+  fi
+  TOKEN="$(printf '%s' "$RAW_CREDS" | python3 -c "
 import json, sys
 try:
     d = json.loads(sys.stdin.read().strip())
@@ -49,31 +65,48 @@ try:
 except Exception:
     sys.exit(1)
 " 2>/dev/null)"
-
-if [ -z "$TOKEN" ]; then
-  show_error "Could not parse Claude Code credentials."
+  if [ -z "$TOKEN" ]; then
+    show_error "Could not parse Claude Code credentials."
+  fi
+  printf '%s' "$TOKEN" > "$TOKEN_CACHE"
 fi
 
-# === Fetch usage from API ===
+# === Load usage from cache or fetch from API ===
 
-response="$(curl -s -w "\n%{http_code}" \
-  -H "Authorization: Bearer ${TOKEN}" \
-  -H "anthropic-beta: oauth-2025-04-20" \
-  -H "Accept: application/json" \
-  "https://api.anthropic.com/api/oauth/usage")"
+parsed=""
 
-http_code="$(printf '%s\n' "$response" | tail -n 1)"
-body="$(printf '%s\n' "$response" | sed '$d')"
-
-if [ "$http_code" = "401" ]; then
-  show_error "Token expired. Please sign in to Claude Code again."
-elif [ "$http_code" -lt 200 ] 2>/dev/null || [ "$http_code" -ge 300 ] 2>/dev/null; then
-  show_error "API Error ($http_code). Response: $body"
+if [ -f "$USAGE_CACHE" ]; then
+  cache_age=$(( $(date -u +%s) - $(stat -f %m "$USAGE_CACHE" 2>/dev/null || echo 0) ))
+  if [ "$cache_age" -lt "$CACHE_TTL" ]; then
+    parsed="$(cat "$USAGE_CACHE" 2>/dev/null)"
+  fi
 fi
 
-# === Parse JSON response ===
+if [ -z "$parsed" ]; then
+  response="$(curl -s --connect-timeout 5 --max-time 10 -w "\n%{http_code}" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    -H "Accept: application/json" \
+    "https://api.anthropic.com/api/oauth/usage")"
 
-parsed="$(printf '%s' "$body" | python3 -c "
+  http_code="$(printf '%s\n' "$response" | tail -n 1)"
+  body="$(printf '%s\n' "$response" | sed '$d')"
+
+  if [ -z "$http_code" ] || [ "$http_code" = "000" ]; then
+    show_error "No internet connection."
+  fi
+
+  if [ "$http_code" = "401" ]; then
+    # Token may be stale — clear cache so next run re-reads from Keychain
+    rm -f "$TOKEN_CACHE"
+    show_error "Token expired. Please sign in to Claude Code again."
+  elif [ "$http_code" = "429" ]; then
+    show_error "Usage API rate limited. Will retry shortly."
+  elif [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+    show_error "API error: HTTP $http_code"
+  fi
+
+  parsed="$(printf '%s' "$body" | python3 -c "
 import json, sys
 try:
     d = json.loads(sys.stdin.read())
@@ -97,8 +130,11 @@ except Exception as e:
     sys.exit(1)
 " 2>/dev/null)"
 
-if [ -z "$parsed" ]; then
-  show_error "Could not parse API response: $body"
+  if [ -z "$parsed" ]; then
+    show_error "Could not parse API response"
+  fi
+
+  printf '%s\n' "$parsed" > "$USAGE_CACHE"
 fi
 
 UTIL_5H="$(      printf '%s\n' "$parsed" | sed -n '1p')"
@@ -153,8 +189,8 @@ except Exception:
 color_for_pct() {
   local pct=$1
   if [ "$COLORS" = "true" ]; then
-    [ "$pct" -ge 90 ] 2>/dev/null && echo "#FF0000" && return
-    [ "$pct" -ge 75 ] 2>/dev/null && echo "#FFD700" && return
+    [ "$pct" -ge 90 ] 2>/dev/null && echo "#CC0000" && return
+    [ "$pct" -ge 70 ] 2>/dev/null && echo "#CC8800" && return
   fi
   echo ""
 }
@@ -179,6 +215,58 @@ make_bar() {
   echo "$bar"
 }
 
+# === Helper: dynamic dual progress bar icon ===
+
+make_icon() {
+  local pct5h="${1:-0}" pct7d="${2:-0}"
+  python3 -c "
+import struct, zlib, base64
+
+def color_for(pct):
+    return (0, 0, 0, 255)
+
+def make_png(w, h, rows_rgba):
+    def chunk(tag, data):
+        c = struct.pack('>I', len(data)) + tag + data
+        return c + struct.pack('>I', zlib.crc32(c[4:]) & 0xffffffff)
+    ihdr = struct.pack('>IIBBBBB', w, h, 8, 6, 0, 0, 0)
+    raw = b''
+    for row in rows_rgba:
+        raw += b'\x00'
+        for (r,g,b,a) in row:
+            raw += bytes([r,g,b,a])
+    idat = zlib.compress(raw)
+    return (b'\x89PNG\r\n\x1a\n'
+            + chunk(b'IHDR', ihdr)
+            + chunk(b'IDAT', idat)
+            + chunk(b'IEND', b''))
+
+W, H = 32, 14
+p5 = min(max(int(round(${pct5h})), 0), 100)
+p7 = min(max(int(round(${pct7d})), 0), 100)
+c5 = color_for(p5)
+c7 = color_for(p7)
+fill5 = int(round(p5 * W / 100))
+fill7 = int(round(p7 * W / 100))
+EMPTY = (0, 0, 0, 60)
+CLEAR = (0, 0, 0, 0)
+
+def bar_row(fill, fg):
+    return [fg if x < fill else EMPTY for x in range(W)]
+
+rows = []
+for row_i in range(H):
+    if 1 <= row_i <= 5:
+        rows.append(bar_row(fill5, c5))
+    elif 9 <= row_i <= 13:
+        rows.append(bar_row(fill7, c7))
+    else:
+        rows.append([CLEAR] * W)
+
+print(base64.b64encode(make_png(W, H, rows)).decode())
+" 2>/dev/null
+}
+
 # === Build menu bar title ===
 
 COLOR_5H="$(color_for_pct "$PCT_5H")"
@@ -201,10 +289,15 @@ else
 fi
 
 # Emit menu bar line
-if [ -n "$TITLE_COLOR" ]; then
-  echo "${TITLE} | templateImage=${CLAUDE_ICON} color=${TITLE_COLOR}"
+if [ "$SHOW_BARS" = "true" ]; then
+  BAR_ICON="$(make_icon "$PCT_5H" "$PCT_7D")"
+  echo " | templateImage=${BAR_ICON}"
 else
-  echo "${TITLE} | templateImage=${CLAUDE_ICON}"
+  if [ -n "$TITLE_COLOR" ]; then
+    echo "${TITLE} | templateImage=${CLAUDE_ICON} color=${TITLE_COLOR}"
+  else
+    echo "${TITLE} | templateImage=${CLAUDE_ICON}"
+  fi
 fi
 
 # === Dropdown ===

--- a/Dev/poe_balance.30m.sh
+++ b/Dev/poe_balance.30m.sh
@@ -2,7 +2,7 @@
 #<xbar.title>Poe Balance</xbar.title>
 #<xbar.version>1.0</xbar.version>
 #<xbar.author>Rodrigo Nemmen da Silva</xbar.author>
-#<xbar.desc>Display remaining Poe API credits</xbar.desc>
+#<xbar.desc>Display remaining Poe API points</xbar.desc>
 #<xbar.image>https://raw.githubusercontent.com/rsnemmen/poe-balance/780b20c79f3433f1908353888a6fa59217f3b8f9/images/cover.png</xbar.image>
 #<xbar.dependencies>curl,bc</xbar.dependencies>
 
@@ -20,9 +20,9 @@ PERCENT=$VAR_PERCENT
 COMPACT=$VAR_COMPACT
 COLORS=$VAR_COLORS
 INITIAL_BALANCE=1000000
-DAILY_CREDITS=32895  # 1M / 30.4 days
+DAILY_POINTS=32895  # 1M / 30.4 days
 
-POE_ICON="iVBORw0KGgoAAAANSUhEUgAAADIAAAAqCAMAAADGZPh1AAAACVBMVEUAAAD///////9zeKVjAAAAA3RSTlP//wDXyg1BAAAACXBIWXMAAC4jAAAuIwF4pT92AAAE9WlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4gPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgMTAuMC1jMDAwIDc5LmQwNGNjMTY5OCwgMjAyNS8wNy8wMi0xMjoxODoxMyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnBob3Rvc2hvcD0iaHR0cDovL25zLmFkb2JlLmNvbS9waG90b3Nob3AvMS4wLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIDI3LjMgKE1hY2ludG9zaCkiIHhtcDpDcmVhdGVEYXRlPSIyMDI2LTAyLTAxVDIwOjEzOjI0LTA4OjAwIiB4bXA6TW9kaWZ5RGF0ZT0iMjAyNi0wMi0wMVQyMTowNTo0Ni0wODowMCIgeG1wOk1ldGFkYXRhRGF0ZT0iMjAyNi0wMi0wMVQyMTowNTo0Ni0wODowMCIgZGM6Zm9ybWF0PSJpbWFnZS9wbmciIHBob3Rvc2hvcDpDb2xvck1vZGU9IjIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6ZDA3MjI4ODItYWE3NC00MThjLThhZjYtMmQ0MzJmYjhhMDVkIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOmQwNzIyODgyLWFhNzQtNDE4Yy04YWY2LTJkNDMyZmI4YTA1ZCIgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOmQwNzIyODgyLWFhNzQtNDE4Yy04YWY2LTJkNDMyZmI4YTA1ZCI+IDx4bXBNTTpIaXN0b3J5PiA8cmRmOlNlcT4gPHJkZjpsaSBzdEV2dDphY3Rpb249ImNyZWF0ZWQiIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6ZDA3MjI4ODItYWE3NC00MThjLThhZjYtMmQ0MzJmYjhhMDVkIiBzdEV2dDp3aGVuPSIyMDI2LTAyLTAxVDIwOjEzOjI0LTA4OjAwIiBzdEV2dDpzb2Z0d2FyZUFnZW50PSJBZG9iZSBQaG90b3Nob3AgMjcuMyAoTWFjaW50b3NoKSIvPiA8L3JkZjpTZXE+IDwveG1wTU06SGlzdG9yeT4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz7iX8W6AAAA40lEQVRIib1USRIEIQjTFP9/MjXVpdi4sNiHyWlsSAgMWlE6uFiAcWSTsYYQM9YgyjXwmcJ+1hSukE92vSVa0SR8g1NKnQ26xnpOzU1Bc8g2YBlGuQb28nw4SAL/+99Pg9mZiCXGUyA3UWwnHA8K5CgY1oD88suOyfJ7oxthfilRlZcBll7gc6BFEcgrb5JOF4wun6QIgbOU+RmiU+xMk3YoZerJHreLjkquQSQZakexanj6DWIMz83xHoPXAMmPwYjWrSjRiCGp5MucUHWZZi7a1HnIcSObidT7uSXEF0j3ksQPw1c2eLCW14gAAAAASUVORK5CYII="
+POE_ICON="iVBORw0KGgoAAAANSUhEUgAAABIAAAAPCAYAAADphp8SAAAAAXNSR0IArs4c6QAAAJhlWElmTU0AKgAAAAgABAEaAAUAAAABAAAAPgEbAAUAAAABAAAARgEoAAMAAAABAAIAAIdpAAQAAAABAAAATgAAAAAAAABIAAAAAQAAAEgAAAABAASQBAACAAAAFAAAAISgAQADAAAAAQABAACgAgAEAAAAAQAAABKgAwAEAAAAAQAAAA8AAAAAMjAyNjowMzoyMCAwODoxNDo0MwBm6dBXAAAACXBIWXMAAAsTAAALEwEAmpwYAAABsmlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iPgogICAgICAgICA8eG1wOkNyZWF0b3JUb29sPkFkb2JlIFBob3Rvc2hvcCAyNy40IChNYWNpbnRvc2gpPC94bXA6Q3JlYXRvclRvb2w+CiAgICAgICAgIDx4bXA6Q3JlYXRlRGF0ZT4yMDI2LTAzLTIwVDA4OjE0OjQzPC94bXA6Q3JlYXRlRGF0ZT4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+CiC5oOMAAAF5SURBVDgRpdI9KMVRGMfx46XL4DXvpbysZPA2WimDUhYWmZRFGcVMYrgpK8bLIGUg5S4GSiZFXuoio7ws3vn+dM7f8XeRPPW55znnf+7/nvM815iPSCHtxxWuv3HJei9+jGKevuD1F3c8z8On0CkUFehDORK4RzrSoHi2IozVOMQ8zhDEENkN5oIVY+rIs725TlDrzWPkKkGHtxZcZdQuNjPqigvephVynUo/oBiDSjCFKphUfdhw18xnrrzMPWAshfa62ri9Oaz1IKI67KABGVBsYRarcBElacGuXci04y1jIaJ6cwkGUINxnEPF1gncyzXXdTWvxCD00mO0o9Udkdw0IY4nuG6Rfgl9pwvdUJeXMOK/SDU5gLp1ikeEQwWOQ6cuQgJqzolq5EJ5FlSPdajduk44HljoxBq0ZwLb/hX0EnVhGZPYh7qVG1LAfBONGMYe3tus0YWutYEZtOEIya6of/gFppHs1EYb6rEIdfJfof+IavCneANwl1NxwdLNXQAAAABJRU5ErkJggg=="
 
 # === Grabs API key === 
 # (inspired by Dev/openai.30m.sh plugin)
@@ -51,13 +51,14 @@ fi
 API_KEY="${API_KEY:-${POE_API_KEY:-}}"
 
 if [ -z "$API_KEY" ]; then
-  echo "⚠️ No API Key"
-  echo "Missing API key. Set API_KEY via export POE_API_KEY in .bashrc or .zshrc." >&2
-  exit 1
+  echo "! | templateImage=$POE_ICON"
+  echo "---"
+  echo "Missing API key. Set POE_API_KEY in .bashrc or .zshrc."
+  exit 0
 fi
 
 # === Fetch balance ===
-response="$(curl -s -w "\n%{http_code}" \
+response="$(curl -s --connect-timeout 5 --max-time 10 -w "\n%{http_code}" \
   -H "Authorization: Bearer ${API_KEY}" \
   -H "Accept: application/json" \
   "https://api.poe.com/usage/current_balance")"
@@ -65,22 +66,31 @@ response="$(curl -s -w "\n%{http_code}" \
 http_code="$(printf '%s\n' "$response" | tail -n 1)"
 body="$(printf '%s\n' "$response" | sed '$d')"
 
-if [ "$http_code" = "401" ]; then
-  echo "⚠️ Invalid Key"
-  exit 1
+if [ -z "$http_code" ] || [ "$http_code" = "000" ]; then
+  echo "? | templateImage=$POE_ICON"
+  echo "---"
+  echo "No internet connection"
+  exit 0
+elif [ "$http_code" = "401" ]; then
+  echo "! | templateImage=$POE_ICON"
+  echo "---"
+  echo "Invalid API key (401)"
+  exit 0
 elif [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-  echo "⚠️ POE API Error ($http_code)"
-  echo "Response body: $body" >&2
-  exit 1
+  echo "! | templateImage=$POE_ICON"
+  echo "---"
+  echo "API error: HTTP $http_code"
+  exit 0
 fi
 
 # Extract balance from JSON (kept simple; assumes integer field)
 balance="$(printf '%s\n' "$body" | sed -n 's/.*"current_point_balance"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')"
 
 if [ -z "$balance" ]; then
-  echo "⚠️ Parse Error"
-  echo "Could not parse current_point_balance from: $body" >&2
-  exit 1
+  echo "! | templateImage=$POE_ICON"
+  echo "---"
+  echo "Could not parse balance from API response"
+  exit 0
 fi
 
 # === Format number ===
@@ -149,13 +159,13 @@ if [ -n "$STARTING_DATE" ] && [ "$STARTING_DATE" -gt 0 ]; then
   DAYS_REMAINING=$(echo "scale=4; ($END_S - $NOW_S) / 86400" | bc)
 
   # Expected remaining balance based on uniform usage
-  ESTIMATED=$(round "$INITIAL_BALANCE - ($DAYS_ELAPSED * $DAILY_CREDITS)")
+  ESTIMATED=$(round "$INITIAL_BALANCE - ($DAYS_ELAPSED * $DAILY_POINTS)")
   if [ "$ESTIMATED" -lt 0 ]; then
     ESTIMATED=0
   fi
   est_pct=$(round "$ESTIMATED / 10000")
 
-  # Actual daily burn rate (credits consumed / days elapsed)
+  # Actual daily burn rate (points consumed / days elapsed)
   if [ "$(echo "$DAYS_ELAPSED > 0" | bc)" -eq 1 ]; then
     ACTUAL_DAILY_BURN=$(round "$consumed / $DAYS_ELAPSED")
   else
@@ -207,6 +217,6 @@ if [ "$HAVE_CYCLE" = "true" ]; then
   DAYS_R=$(round "$DAYS_REMAINING")
   TOTAL_DAYS=$((DAYS_E + DAYS_R))
   echo "Day ${DAYS_E} of ${TOTAL_DAYS} (${DAYS_R} remaining)"
-  echo "Daily burn: $(format_number "$ACTUAL_DAILY_BURN") (expected: $(format_number "$DAILY_CREDITS"))"
+  echo "Daily burn: $(format_number "$ACTUAL_DAILY_BURN") (expected: $(format_number "$DAILY_POINTS"))"
   echo "Projected end balance: $(format_number "$PROJECTED")"
 fi


### PR DESCRIPTION
poe_balance: Rename credits→points, improve error handling and curl robustness

  - Rename all "credits" references to "points" (desc metadata, DAILY_POINTS constant, comments) to match Poe's current terminology
  - Update POE_ICON to larger logo
  - Follow SwiftBar protocol on errors: use templateImage icon + dropdown message and exit 0 (instead of emoji text + exit 1), so the Poe icon always appears in the menu bar even on failure
  - Add explicit no-internet check (HTTP status 000)
  - Add --connect-timeout 5 --max-time 10 to curl to avoid hangs

claude_code: add progress bars, caching, and improved error handling

  - Add VAR_SHOW_BARS option (default true): dynamic dual progress bar PNG icon (5h top, 7d bottom) generated via make_icon; replaces static Claude logo + percentage text in the menu bar
  - Cache OAuth token (/tmp/.claude_swiftbar_token, 15 min TTL) and API response (/tmp/.claude_swiftbar_cache, 5 min TTL) to avoid redundant Keychain reads and API calls on every 5-minute poll
  - Add curl timeouts (--connect-timeout 5 --max-time 10)
  - Handle no-internet (HTTP 000) and rate-limit (HTTP 429) error cases
  - Adjust color thresholds: warning #CC8800 at ≥70% (was #FFD700 at ≥75%), critical #CC0000 at ≥90% (was #FF0000)