### PR TITLE
Fix three crypto plugins silently broken by the Nomics and CoinCap shutdowns

### DIFF
--- a/Cryptocurrency/Dash/dash-coincap-poloniex.5m.sh
+++ b/Cryptocurrency/Dash/dash-coincap-poloniex.5m.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# <xbar.title>Dash tickers: Coincap.io and Poloniex.com</xbar.title>
-# <xbar.version>v1.1</xbar.version>
-# <xbar.author>UdjinM6</xbar.author>
-# <xbar.author.github>UdjinM6</xbar.author.github>
-# <xbar.desc>Shows the latest Dash info from Coincap.io and Poloniex.com</xbar.desc>
+# <xbar.title>Dash tickers: CoinPaprika.com and Poloniex.com</xbar.title>
+# <xbar.version>v1.2</xbar.version>
+# <xbar.author>UdjinM6, Mateusz Sroka</xbar.author>
+# <xbar.author.github>UdjinM6,donbagger</xbar.author.github>
+# <xbar.desc>Shows the latest Dash info from CoinPaprika.com and Poloniex.com</xbar.desc>
 # <xbar.image>https://i.imgur.com/BRmoB48.png</xbar.image>
 # <xbar.abouturl>https://www.dash.org/</xbar.abouturl>
 
@@ -14,61 +14,63 @@
 iconBase64='iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAB3RJTUUH4wsdAAwGzHGX5gAAAg5JREFUWMPt1z1oVEEQB/DfhRON+JXCmGKDIoiKmEIhIIhKCmsLwSKihb0EXikWChYi1ykIQggIFjaCglUghWJhLCwUFItYPPwKQvBiJDEhFnkHIu/d7TsuscnAcTA7uzPz35n/7GNd/rNUoqxq6QhGSpw7i3f4hQk8lYQveYbVyAMPYHfJ5A5l/+ezJF5mSUxKwmLDqCsi+y3Y2wG0B/ECd9XS7jIIbMbODl77JWxqINMVsWE79uB3i98CliKDGFZLT8Yi8B1J5qCZLKMbIauXY9if6fOK/RYGK6vSW7W0msF8EbebJLavsuqNXkuv42rOSh1DXWvANfcxV0ABfWsRwCymCmpmvvoXVGcwip4Sh8/jsCR8aMG2eVe9hB/VzPkRPGoju0lMR7Rxf45+AVONK7jcJrxvJGGmhU0PtuboFyXhWyOAC204r+NhhN2JAv3blUqspf34mrFZzPSs4xNGJWEiYs/ZAv3jRit8xkBWlTGyhAVJ+BnBAf04WrA6uhLAymicXqUWHCvQP5eEeuwwapcBb2CoYPVK2QdJGccHcQenCizG8ap5ALV0Q3ZAb4TLZWzEcZzOpmEzVrwpCXOtEOjDvTaeYa3kmiSMx7wJd2Bbh50PS8KDf5VFRdhbciY0kxTn8pw3Q2CgA46f4QnGJKGwzYsC2IX3JdhxJqvs1/iY7a1Lwuz6p9e6tJI/DAh9aD+iV7oAAAAASUVORK5CYII='
 
 # Grab all info beforehand
-token_info_poloniex=$(curl -s https://poloniex.com/public?command=returnTicker | tr '}' '\n' | grep BTC_DASH | tr -d '{}"' | tr ':,' '\n')
-token_info_coincap=$(curl -s https://api.coincap.io/v2/assets/dash/ | tr -d '{}" ' | tr ':,' '\n')
-btc_info_coincap=$(curl -s https://api.coincap.io/v2/assets/bitcoin/ | tr -d '{}" ' | tr ':,' '\n')
+# Poloniex retired its legacy public API (HTTP 410), the markets API replaces it.
+# Coincap.io shut down entirely, the free keyless CoinPaprika API replaces it.
+token_info_poloniex=$(curl -s "https://api.poloniex.com/markets/DASH_BTC/ticker24h" | tr -d '"' | tr ',{}' '\n')
+token_info_cp=$(curl -s "https://api.coinpaprika.com/v1/tickers/dash-dash?quotes=USD" | tr -d '"' | tr ',{}' '\n')
+btc_info_cp=$(curl -s "https://api.coinpaprika.com/v1/tickers/btc-bitcoin?quotes=USD" | tr -d '"' | tr ',{}' '\n')
 
 # Menu bar
-token_price_btc=$(echo "$token_info_poloniex" | grep -A1 last | tail -1)
-token_price_usd=$(echo "$token_info_coincap" | grep -A1 priceUsd | tail -1)
+token_price_btc=$(echo "$token_info_poloniex" | grep '^close:' | cut -d: -f2)
+token_price_usd=$(echo "$token_info_cp" | grep '^price:' | cut -d: -f2)
 token_price_btc_precision=6
 if (( $(echo "$token_price_usd >= 100" | bc -l) )); then token_price_usd_precision="$((token_price_btc_precision-3))"; else token_price_usd_precision="$((token_price_btc_precision-2))"; fi
 printf "%.*f | dropdown=false image=%s\n" "$token_price_btc_precision" "$token_price_btc" "$iconBase64"
-printf "$%.*f | dropdown=false image=%s\n" "$token_price_usd_precision" "$token_price_usd" "$iconBase64"
+printf "\$%.*f | dropdown=false image=%s\n" "$token_price_usd_precision" "$token_price_usd" "$iconBase64"
 
 # BTC
-btc_percent_change_24h=$(echo "$btc_info_coincap" | grep -A1 changePercent24Hr | tail -1)
-if (( $(echo "$btc_percent_change_24h >= 0" | bc -l) )); then btc_color_coincap="green"; else btc_color_coincap="red"; fi
-btc_usd_price=$(echo "$btc_info_coincap" | grep -A1 priceUsd | tail -1)
+btc_percent_change_24h=$(echo "$btc_info_cp" | grep '^percent_change_24h:' | cut -d: -f2)
+if (( $(echo "$btc_percent_change_24h >= 0" | bc -l) )); then btc_color_cp="green"; else btc_color_cp="red"; fi
+btc_usd_price=$(echo "$btc_info_cp" | grep '^price:' | cut -d: -f2)
 echo "---"
-printf ":moneybag: BTC: $%.*f | color=$btc_color_coincap href=\"http://coincap.io/assets/bitcoin/\"\n" 2 "$btc_usd_price"
+printf ":moneybag: BTC: \$%.*f | color=%s href=\"%s\"\n" 2 "$btc_usd_price" "$btc_color_cp" "https://coinpaprika.com/coin/btc-bitcoin/"
 
-# Coincap.io
-token_percent_change_24h=$(echo "$token_info_coincap" | grep -A1 changePercent24Hr | tail -1)
-if (( $(echo "$token_percent_change_24h >= 0" | bc -l) )); then token_color_coincap="green"; else token_color_coincap="red"; fi
-token_rank=$(echo "$token_info_coincap" | grep -A1 rank | tail -1)
-token_available_supply=$(echo "$token_info_coincap" | grep -A1 supply | tail -1)
+# CoinPaprika.com
+token_percent_change_24h=$(echo "$token_info_cp" | grep '^percent_change_24h:' | cut -d: -f2)
+if (( $(echo "$token_percent_change_24h >= 0" | bc -l) )); then token_color_cp="green"; else token_color_cp="red"; fi
+token_rank=$(echo "$token_info_cp" | grep '^rank:' | cut -d: -f2)
+token_available_supply=$(echo "$token_info_cp" | grep '^total_supply:' | cut -d: -f2)
 token_available_supply_mln=$(echo "$token_available_supply / 1000000" | bc -l)
-token_market_cap_usd=$(echo "$token_info_coincap" | grep -A1 marketCapUsd | tail -1)
+token_market_cap_usd=$(echo "$token_info_cp" | grep '^market_cap:' | cut -d: -f2)
 token_market_cap_usd_mln=$(echo "$token_market_cap_usd / 1000000" | bc -l)
-token_volume_usd=$(echo "$token_info_coincap" | grep -A1 volumeUsd24Hr | tail -1)
+token_volume_usd=$(echo "$token_info_cp" | grep '^volume_24h:' | cut -d: -f2)
 token_volume_usd_m=$(echo "$token_volume_usd / 1000000" | bc -l)
 echo "---"
-echo ":chart_with_upwards_trend: Coincap.io: | href=\"http://coincap.io/assets/dash/\""
+echo ":chart_with_upwards_trend: CoinPaprika.com: | href=\"https://coinpaprika.com/coin/dash-dash/\""
 printf "%sRank: %.*f\n" "* " 0 "$token_rank"
 printf "%sSupply: %.*fM DASH\n" "* " 2 "$token_available_supply_mln"
-printf "%sMarket Cap: $%.*fM | color=$token_color_coincap\n" "* " 2 "$token_market_cap_usd_mln"
-printf "%sPrice: $%.*f | color=$token_color_coincap\n" "* " 2 "$token_price_usd"
-printf "%s24h Change: %.*f%% | color=$token_color_coincap\n" "* " 2 "$token_percent_change_24h"
-printf "%s24h Volume: $%.*fM\n" "* " 2 "$token_volume_usd_m"
+printf "%sMarket Cap: \$%.*fM | color=%s\n" "* " 2 "$token_market_cap_usd_mln" "$token_color_cp"
+printf "%sPrice: \$%.*f | color=%s\n" "* " 2 "$token_price_usd" "$token_color_cp"
+printf "%s24h Change: %.*f%% | color=%s\n" "* " 2 "$token_percent_change_24h" "$token_color_cp"
+printf "%s24h Volume: \$%.*fM\n" "* " 2 "$token_volume_usd_m"
 
 # Poloniex.com
-token_percent_change=$(echo "$token_info_poloniex" | grep -A1 percentChange | tail -1)
+token_percent_change=$(echo "$token_info_poloniex" | grep '^dailyChange:' | cut -d: -f2)
 token_percent_change=$( echo "$token_percent_change * 100" | bc -l )
 if (( $(echo "$token_percent_change >= 0" | bc -l) )); then token_color_poloniex="green"; else token_color_poloniex="red"; fi
-token_lowest_ask=$(echo "$token_info_poloniex" | grep -A1 lowestAsk | tail -1)
-token_highest_bid=$(echo "$token_info_poloniex" | grep -A1 highestBid | tail -1)
-token_base_volume=$(echo "$token_info_poloniex" | grep -A1 baseVolume | tail -1)
-token_quote_volume=$(echo "$token_info_poloniex" | grep -A1 quoteVolume | tail -1)
+token_lowest_ask=$(echo "$token_info_poloniex" | grep '^ask:' | cut -d: -f2)
+token_highest_bid=$(echo "$token_info_poloniex" | grep '^bid:' | cut -d: -f2)
+token_base_volume=$(echo "$token_info_poloniex" | grep '^amount:' | cut -d: -f2)
+token_quote_volume=$(echo "$token_info_poloniex" | grep '^quantity:' | cut -d: -f2)
 token_quote_volume_k=$(echo "$token_quote_volume / 1000" | bc -l)
-token_high_24h=$(echo "$token_info_poloniex" | grep -A1 high24hr | tail -1)
-token_low_24h=$(echo "$token_info_poloniex" | grep -A1 low24hr | tail -1)
+token_high_24h=$(echo "$token_info_poloniex" | grep '^high:' | cut -d: -f2)
+token_low_24h=$(echo "$token_info_poloniex" | grep '^low:' | cut -d: -f2)
 echo "---"
-echo ":chart_with_upwards_trend: Poloniex.com: | href=\"https://poloniex.com/exchange#btc_dash\""
-printf "%sPrice: %.*f BTC | color=$token_color_poloniex\n" "* " 6 "$token_price_btc"
+echo ":chart_with_upwards_trend: Poloniex.com: | href=\"https://poloniex.com/trade/DASH_BTC\""
+printf "%sPrice: %.*f BTC | color=%s\n" "* " 6 "$token_price_btc" "$token_color_poloniex"
 printf "%sAsk: %.*f BTC\n" "* " 6 "$token_lowest_ask"
 printf "%sBid: %.*f BTC\n" "* " 6 "$token_highest_bid"
-printf "%s24h Change: %.*f%% | color=$token_color_poloniex\n" "* " 2 "$token_percent_change"
+printf "%s24h Change: %.*f%% | color=%s\n" "* " 2 "$token_percent_change" "$token_color_poloniex"
 printf "%s24h Volume: %.*f BTC\n" "* " 2 "$token_base_volume"
 printf "%s24h Volume: %.*fK DASH\n" "* " 2 "$token_quote_volume_k"
 printf "%s24h High: %.*f BTC | color=green\n" "* " 6 "$token_high_24h"

--- a/Cryptocurrency/coincap.1m.py
+++ b/Cryptocurrency/coincap.1m.py
@@ -1,59 +1,49 @@
 #!/usr/bin/env python3
 
-# <xbar.title>CoinCap</xbar.title>
-# <xbar.version>v1.0</xbar.version>
-# <xbar.author>Peter Stenger</xbar.author>
-# <xbar.author.github>reteps</xbar.author.github>
-# <xbar.desc>Retrieves trading information about a coin on cryptocompare and coinmarketcap. High & low not available on CMC.</xbar.desc>
+# <xbar.title>Crypto tickers (CoinPaprika)</xbar.title>
+# <xbar.version>v1.1</xbar.version>
+# <xbar.author>Peter Stenger, Mateusz Sroka</xbar.author>
+# <xbar.author.github>reteps,donbagger</xbar.author.github>
+# <xbar.desc>Retrieves trading information about coins from the free CoinPaprika API, no key needed. Change is over the last 24h, open/high/low are for the current UTC day.</xbar.desc>
 # <xbar.image>https://i.imgur.com/a584lGl.png</xbar.image>
-# <xbar.dependencies>python3,requests</xbar.dependencies>
+# <xbar.dependencies>python3</xbar.dependencies>
+# <xbar.abouturl>https://coinpaprika.com</xbar.abouturl>
 
-coins_usd = ['bitcoin','ethereum','litecoin'] #USD
+# CoinPaprika coin ids, full list at https://api.coinpaprika.com/v1/coins
+coins_usd = ['btc-bitcoin', 'eth-ethereum', 'ltc-litecoin', 'miota-iota'] #USD
 
-coins_btc = ['neo','walton','stellar','monero'] #BTC
-
-coins_cmcbtc = ['raiblocks'] #Coinmarketcap BTC
-
-coins_cmcusd = ['iota'] #CoinmarketCap USD
+coins_btc = ['neo-neo', 'xlm-stellar', 'xmr-monero', 'xno-nano'] #BTC
+# raiblocks is called nano these days; waltonchain no longer trades anywhere,
+# so it was dropped from the defaults
 
 #------------------------------BEGIN CODE------------------------------#
-import requests
+import json
+from urllib.request import Request, urlopen
+
+API = 'https://api.coinpaprika.com/v1'
+
+# the API rejects the default Python-urllib user agent, hence the header
+def fetch(path):
+    request = Request(API + path, headers={'User-Agent': 'xbar-plugin'})
+    with urlopen(request, timeout=15) as response:
+        return json.load(response)
+
 print('Ƀ')
 print('---')
-coin_data_usd = {}
-coin_data_btc = {}
-standard = "|href='https://coinmarketcap.com/currencies/{}' font='Menlo'"
+standard = "|href='https://coinpaprika.com/coin/{}/' font='Menlo'"
 usd = "{: <5} {:0<9.3f} {:0<+6.2f}% {:0<9.3f} {:0<9.3f} {:0<9.3f}  {:0>3}" + standard
 btc = "{: <5} {:0<9.7f} {:0<+6.2f}% {:0<9.7f} {:0<9.7f} {:0<9.7f}  {:0>3}" + standard
-#----DATA----#
-for coin in coins_usd:
-    data = requests.get("https://api.coinmarketcap.com/v1/ticker/{}".format(coin)).json()[0]
-    coin_data_usd[data["symbol"]] = data['rank']
-for coin in coins_btc:
-    data = requests.get("https://api.coinmarketcap.com/v1/ticker/{}".format(coin)).json()[0]
-    coin_data_btc[data["symbol"]] = data['rank'] 
-raw_usd = requests.get('https://min-api.cryptocompare.com/data/pricemultifull?fsyms={}&tsyms=USD'.format(','.join(coin_data_usd.keys()))).json()['RAW']
-raw_btc = requests.get('https://min-api.cryptocompare.com/data/pricemultifull?fsyms={}&tsyms=BTC'.format(','.join(coin_data_btc.keys()))).json()['RAW']
-raw_cmcbtc = [requests.get('https://api.coinmarketcap.com/v1/ticker/{}'.format(coin)).json()[0] for coin in coins_cmcbtc]
-raw_cmcusd = [requests.get('https://api.coinmarketcap.com/v1/ticker/{}'.format(coin)).json()[0] for coin in coins_cmcusd]
-#---HELPER---#
-def f(x):
-    return float(x)
 
 #----DISPLAY----#
+def print_rows(coins, quote, fmt):
+    for coin in coins:
+        ticker = fetch('/tickers/{}?quotes={}'.format(coin, quote))
+        ohlcv = fetch('/coins/{}/ohlcv/today?quote={}'.format(coin, quote.lower()))[0]
+        data = ticker['quotes'][quote]
+        print(fmt.format(ticker['symbol'], data['price'], data['percent_change_24h'],
+                         ohlcv['open'], ohlcv['high'], ohlcv['low'], ticker['rank'], coin))
+
 print('COIN     USD     CHANGE   OPEN      HIGH       LOW    RANK|font="Menlo"')
-#---USD---#
-for i, coin in enumerate(coin_data_usd.keys()):
-    data = raw_usd[coin]["USD"]
-    print(usd.format(coin,data["PRICE"],data['CHANGEPCT24HOUR'],data['OPEN24HOUR'],data['HIGH24HOUR'],data['LOW24HOUR'],coin_data_usd[coin],coins_usd[i]))
-for i, coin in enumerate(coins_cmcusd):
-    data = raw_cmcusd[i]
-    print(usd.format(data["symbol"],f(data["price_usd"]),f(data['percent_change_24h']),f(data["price_usd"])*((100-f(data['percent_change_24h']))/100),0.000,0.000,data['rank'],coin))
-#---BTC---#
+print_rows(coins_usd, 'USD', usd)
 print('COIN     BTC     CHANGE   OPEN      HIGH       LOW    RANK|font="Menlo"')
-for i, coin in enumerate(coin_data_btc.keys()):
-    data = raw_btc[coin]["BTC"]
-    print(btc.format(coin,data["PRICE"],data['CHANGEPCT24HOUR'],data['OPEN24HOUR'],data['HIGH24HOUR'],data['LOW24HOUR'],coin_data_btc[coin],coins_btc[i]))
-for i, coin in enumerate(coins_cmcbtc):
-    data = raw_cmcbtc[i]
-    print(btc.format(data["symbol"],f(data["price_btc"]),f(data['percent_change_24h']),f(data["price_btc"])*((100-f(data['percent_change_24h']))/100),0.000,0.000,data['rank'],coin))
+print_rows(coins_btc, 'BTC', btc)

--- a/Cryptocurrency/nomics_bitbar.py
+++ b/Cryptocurrency/nomics_bitbar.py
@@ -1,51 +1,29 @@
-#!/usr/bin/env LC_ALL=en_US.UTF-8 /usr/local/bin/python
+#!/usr/bin/env python3
 
 '''
     All metadata is placed here
 '''
-# <xbar.title>Nomics.com Cryptocurrency Tickers</xbar.title>
-# <xbar.version>v1.0</xbar.version>
-# <xbar.author>Daniel Anderson</xbar.author>
-# <xbar.author.github>dtand</xbar.author.github>
-# <xbar.desc>Provides price updates and 24h change for the top ten cryptocurrencies by marketcap.</xbar.desc>
+# <xbar.title>CoinPaprika Cryptocurrency Tickers</xbar.title>
+# <xbar.version>v1.1</xbar.version>
+# <xbar.author>Daniel Anderson, Mateusz Sroka</xbar.author>
+# <xbar.author.github>dtand,donbagger</xbar.author.github>
+# <xbar.desc>Provides price updates and 24h change for the top ten cryptocurrencies by marketcap. Data comes from the free CoinPaprika API, no key needed. This plugin used Nomics before that service shut down.</xbar.desc>
 # <xbar.image>https://i.ibb.co/4SD8cZs/Screen-Shot-2019-11-25-at-6-16-56-PM.png</xbar.image>
-# <xbar.dependencies>python,requests</xbar.dependencies>
-# <xbar.abouturl>https://nomics.com</xbar.abouturl>
-import requests
+# <xbar.dependencies>python3</xbar.dependencies>
+# <xbar.abouturl>https://coinpaprika.com</xbar.abouturl>
+import json
+from urllib.request import Request, urlopen
 
 
-## Base url for api
-BASE_URL = 'https://api.nomics.com/v1'
+## Tickers endpoint for the top ten coins by marketcap, no API key required
+TICKERS_URL = 'https://api.coinpaprika.com/v1/tickers?quotes=USD&limit=10'
 
-## Tickers endpoint
-ENDPOINT = 'currencies/ticker'
-
-## FREE API key
-API_KEY = '4465bf5e9801e08b9a3e04084c7ea3c3'
-
-## Returns top ten cryptocurrencies
-def get_top_ten():
-    url = "{}/currencies/ticker?key={}".format(BASE_URL, API_KEY)
-    response = requests.get(url)
-    data = response.json()
-    top_ten = []
-    i = 0 
-    for ticker in data:
-        if i >= 10:
-            break
-        top_ten.append(ticker["id"])
-        i = i + 1
-    return top_ten
-
-## Returns ticker for provided symbol
-def get_tickers(symbols):
-    params = {
-        "ids": symbols
-    }
-    url = '{}/{}?key={}'.format(BASE_URL, ENDPOINT, API_KEY)
-    response = requests.get(url, params=params)
-    data = response.json()
-    return data
+## Returns tickers for the top ten cryptocurrencies
+## (the API rejects the default Python-urllib user agent)
+def get_tickers():
+    request = Request(TICKERS_URL, headers={'User-Agent': 'xbar-plugin'})
+    with urlopen(request, timeout=15) as response:
+        return json.load(response)
 
 ## Pads string to certain length
 def pad_string(string, length):
@@ -53,52 +31,47 @@ def pad_string(string, length):
     return string.ljust(padding)
 
 ## Returns the string specification for stdout
-## for bitbar interpreter
-def generate_bitbar_format(tickers):
+## for the xbar interpreter
+def generate_xbar_format(tickers):
     std_out_strings = []
-    i = 1
     for ticker in tickers:
         symbol   = ticker['symbol']
+        quote    = ticker['quotes']['USD']
 
-        price    = round(float(ticker['price']),4)
+        price    = round(float(quote['price']),4)
 
         if price < 1.00:
             price = '${:,.4f}'.format(price)
         else:
             price = '${:,.2f}'.format(price)
 
-        p = abs(float(ticker['1d']['price_change_pct']))
-        percent  = round(p * 100, 2)
+        change   = float(quote['percent_change_24h'])
+        percent  = round(abs(change), 2)
         percent  = str(percent) + "%"
 
         col_one = pad_string(symbol + ": " + price, 24)
 
-        if float(ticker['1d']['price_change_pct']) >= 0:
+        if change >= 0:
             std_out_strings.append(col_one + "\t+" + percent + " | color=green")
         else:
             std_out_strings.append(col_one + "\t-" + percent + " | color=red")
 
-        i = i + 1
-
     return std_out_strings
 
-## Print output with bitbar formatting between new lines
+## Print output with xbar formatting between new lines
 def output_values(values):
-    print(" Nomics.com | image=iVBORw0KGgoAAAANSUhEUgAAADYAAAA2CAYAAACMRWrdAAABk2lDQ1BJQ0MgUHJvZmlsZQAAKJF9kL1LQmEUxh+vhVFGgw0ODReyWjTMIGpLDUQwEDPIauh+qFfQ6+V6pYLGoKVBaOhj6Wtoaa7VoTUIiiKIlv6DvpaQ23m9hlbUgZfz43nPOe95H4DbFDQt3+YHCqqhJyIhfi41zzue0AU3XBjDkCCVtGA8HgPFV/4e77ewsXztY7N+3/8b3XK6JAE2nnhS0nSDeIm4f9nQGK8T9+q0FPEO46zFp4xFi6v1mmQiTHxDzEuKIBO/EnslRS8AHJvvkQsy6dyUxSpjhbHY0ptt4UK+LDX2ZD90ptXZGVZPpw8RRDGNOHiIKCOHPAz4KKuklJCg+5CRXjFYc7ioreq5rGLwQXIozUdVadjLB/wjEwDz+6ePTa14AIy/AfZKUxO3gfMNwH3f1Dz7QA95dXahCbpQl+x0uEwGeD4hm1OA6wroXChlRgPWj5whoP3RNF8GAMcWUKuY5sehadaOqPkBqKqWd41ZOL4DkmtA7BLY3QMGs/Tm4h8eddQ9avjwb03Dx0/wyngPzfkFKgAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAExxJREFUaAWtmumTHdV5xp/Tt++dO/to3xAYgcAIwmKxJbEDXgIuB5JyUiJxEsehXEU+pJLKf8DwLyRVqZAPMQmuioPKibEowGUSFMwmhGIEJcKiAEK7Rvtsd+vu/J5z75VGI80izJF6um/3Oe/7Pu921iDK6GiRbNqjsJXnrVtD5nf/8t2iv7xfN2hKtzcntCmf1FqdVr8mlYQ+ZWEJX4Z0KBnUO6XlenPpsD64/8kw6baFiuSxe5Xs2a4CmrkUCr8/X4qwRUpu5MOjfA8K1JG2PVL0Nce0sXZYd+QT+rVsQlfkp9RXnFUp6YMoPMOQjhb9+jAZ0OuDV+vt3/unMO62o3zeBL13YT8KvVAURdBjCoEvFgCQ6YbntVETur3U0G3lhjaEhpblNQ0XU6qojiRlqTSgRtKrM3mPjjYq+rhI9TaMd1VWa+9DW0MjMtoCoxthNNoW3ALAFyYK27cr+fvtBh6yxx8pyn17tAGl3V6q62auDaGu1QU8AVeBfxA8UWuz1KOz6tHJrKyPm1W9VSzRzhW36v1v/R0tKE+pKKE0gGGt0GH81OZiuBl0fTKt+4tJfbU0pevSmnoBU8ozpUWuxPBdQonGKZbrUQMGk60e7SsN6oVKn54/uFxv//VzoY7lAqoMepSH0Laa+Qnv0FZ/DPnojUXl+lQ3Fk19M5/WfZVpXRWmNYiYlaKlUpHBMzKEJ9y5WqGiVlZVPevTR8WAfoEFn2sNac/3XtBJTFTYY9LHYiuQGtSEvgTB301b+hra2lSeUppNAx8wxhMxhc5DC6txWU9YdTnwryzlGsky9S3h1bYHi7fCtjBlHzEjt47tZ4B6VkXP0bO6mY8PEgAP5E3dgjITwTPDOaN/dkBFh+aF2SeNyFNqahXgVzRzPCrRT/75G9rxPemEMbmeHsEVvrxLX6qc0B8Vp/WdyoSW52gLmbN6QKoCsqjXdbslCskfq7PErZdbqNJgWB+hvW3VJfpB9aTe+9beUHcMC9e7h7r3bm/H1A9UVIsyykv1J+VcD3BtVKYwlQvdKI+g4HgB0zZzjKikUsjsElyzaCzReD6srWGpfli/XjsefiLUUte9e7c24nL3E1NfLwGq0VLAGM0MqUtBCS4Y67Xptv9Ghv4ThJcqn0aSHlw2IeB7SvoKrnnw9ArVR/+02EuMtR7H98eoF91PRVov66Zqpj/uyXQfpryqCSV4ZlTIA5VwXOvs4gJPZCpaOEAtV6vSAOQpDWUl3dNKdbJyUGdo9FbiTNRT02ac5qtFXTdkWAomeQt/xiCRAbSSS11wRga+IUgrKGsUynDhSjGta5vT+iZuvHnDq1pq6XDP/CESxV9dW/SsTXXnQKaHego9AKhrs8I6UU58R8+wI1yKn99FnoDmOeB+BTzzVh31TuoalPrlZEx3vPg3xUg6cUCb0rpuA9jG8rTSCbTWpHX8XxC8mPxS/mBhIe7QcVZIyAR2kayBO5VqGiKD3oaPbu47o3eodcyg/paYGvhEm3G7PygVxLJ0jcO0ASDa2/vwesjOZa02v1jJpudfglcVddx3cFqlLNXVWY9uPf4W3UF2QnclNW0oTauXrCTi0sUaweLzF4RAhvjHmiyZGZYrMkxentBIua6rG02tfZEuxKBKZd1cyfX7aaEHqW9LBarGmLJyHKvzguqIE3m269KEXALPHJODoZrQVTTHdXdKr7AJF1zBh9TZD0Q5xN2gXay/jnG6r7p3PszEnth3ERbVSWkDgJmWJrlWH/ml1iy9TYPFQW1Jm3ogaeoag681SRfYyd6B2d3ZzekdM3ni+hi4o1PaYXkiCJ4tuiQydGtKN6QAupLoH0EAFAlli+qH9m2m4O2Xl/gbmdCmWzn+RkQs1N+qaGPrNM+51lcG9Ntq6Sr4Jc0GSWIKTjVA4b4zml+Cw/yvYocIAVJpCv1h+t0rUnxvOG+oiubs3xbOTIytK+f8VP3VDSh0nDEH297uh7DYsta47sI1bm4xJKPPuQ6iVbRbtEqkyV5AVeEHMI9o4uVIWzxns43FIgAswfuquMBQyhgwtdZI6W35OkJ26i98QwhrzMIEOrPYl9EqY9TYGtPK/DAaNIB+9U4HMiYummOphC7FoHzF4ZI7FANykOPK85VZSo89v8WwW0O75LBK83HSOi9Ms/1nPpIXfnNMOUAMxo5OhxtIvcI6pNYYB309Ul/lC8TdFbwnNbTOEnuH+X6AzpgxYDhLohkiPlAKA1sxtBLjVI8q2iUK1nme5xaV6+8ZimvRUeIeHgZfLqbIgvGisEYExnBI2XHT5ffV0uANjFmvUNG/EkMuBfMAfBJyPn1O7RSgjkmTAJw6SBs6hOZRwHkoQYcXhfGY3eCsvAXAde1CzW4pUud1l8vyQFe26/TDk1E3MaommoeB+r4hLb9LWnGTNLJORe8SQNkaVgK80GbIqF+j/jiKOPWRNHaNdPpJQqyG9bB2qY+qg9SnDslgwYLT2DYXQEhxpdCdVFzwZS5yVoQvW8qg6PvsegnCLblXWgOo1UyMRq5Q6F8qMdovsGxMtiYZeaCBFuCmscqyq6ThtdJhXHXsFcC9RCXcObXlcFHZcosAR63zBfk8FXExY4s7f7FUruWYIgO6UzSoArdb9lvShvuldbci6Gq0DugIaFbPFJmg4jI0StDoG0b+VVyAq45IB+BRexm6WC/FctZE0QF3TjuzpATCRbLboS67RFAEUwOGyQZc7yttUFfejoAdUCbq5BITzBwcLGiKAgaWtxWRII1ddj/3iReR1pYDeIw1PONctpwFw644m8XlAUMIuyDzaGUEv409co/0hfuk9ZtJGGjelpoPzEwBInCEdJz34narrmt/rRNbjTexmhXHe3cjkdnUzNbzPwN2EaWrebvGAKD4bbfvxVJr7sD9bmm7XwrgKCyIFwMuupZp25eQpBfrLCdW190pLf0uDLB+E1d3h89M/bLKwsBmmN0uaCYN/F9rYI4Aq4ivYZ4dLzEebEbaxKBd5J0W5xRhy638InShXUFhzOrjtCFmYfOYIY/buVgv7afzfxcGhkajoHZD4orpiDJcpId0vpxlJlJ6dL8IylVngDnPZu6naDWL1fGKEoobXNHOlkPrcUU+OfN6ccHeEgFaJl+dwqcZv9ov5wbW0UFs4UikX2FkETOhm/ZhpSFAOaU76GM9/+kAc53LLp32PfSPA4AzsDLPngl4ZSzGGi7pTivaqCPjpfjMDWxmbVzARAvudLBxTsNoQv2k5wqMPRm7WGczCSziuSssVT2iqWKdARRXuRue8IqLIPaaRaa7xQGDkQeqBXem4yoRB1UCnc637YaLkPtyqzhmqwCq0HGzxMY0uW2khSzV5bM4YB1txoyHxhLchClHdMEYI11qn+PdVnOWdSftEU6c0nRcdTFsFgdsFqVzAT/DfWZV+Xx/AsiYfF2qfLasaEodqjHjEWP5GBcp3yP6zpDsUvx+pXem66ThBVuvEsWuxoqcC90sbosLRQi7RzYwJojKSPkeHbDEFpNJHLnPIvyr/oxrIqwQNo/Al07awDy1jx3/LHC43aw3yLmgAG5iy2AhNgfiCAFsmjrJ6NzgABmZWZufUzG9BnQnAVX/X3gC0Mpj7tge8iyCz9zAOjqI8gLM0wevlZUYlbtMH2W6BOOp01jNruKKvmgXgbrS5ZQOPzexJ0yegP5+AO6Dp+lzOTNayVEm1++0+WwxZugWFmu5D/EE0DPd+l5W/z+QzgDOfVu3GFT36r6b7x6VgGQuVo6VNHFcOgmo8YNt2dkbY2WUCrhkHOnHyv7TLp/dFd3e2rG2EMIpOAfUiZ3SkfcRwMkEcDG5zLCaE0AE6eYzAF/0zHcPgl3qCD/2oXT0TeZluzvditO9lecxakcJPM1bFpc8IBHltcYQ0FMT0598DmAbzk8s47zKFA1iLgGsoE6JjxCOIxfe1Ymrk59Kh/5HOv4MND5mXLCCD1YQSo3K7bRd6LY4YEZFie6I5jxHSnFJVrh05iXpE1zTGvfseZBJYxSU31GQTttIYNafaOHOO4M6AZBPX0dZrwLyPXigwBISeuAdrTWr/Xw/03n4XtjOFTvatjXYh1aZTOUVpmPcvfzmHLtmUwccv7uWuIDQTIbQc0zV8ARb6tMd0r6nibGX2i5YYiwa1xkNrBvHM9tfQPjCH9Fi1LXIHbEvrHDuF19j5vMLMwJE4skf47iMWDjK9yZZa4p482LO0Jr2xLFM/9NOY9zbJfIxoMakwgTZb2xv2/2OvYZ7vwhdgJZW0gx6BfOxhUBZtC7x7j0FTlxX7L5Y8G6xrD0zhFzSzx2XaRgcV+0PSSZkymXXzgCHAojLuGJL4oi7MSSJMIESTh3E4ruIqZ9C4//aiSmCMg9c/VJZkLfzF2RMHePOUhdjnqet9QPjuHqExRJizCN9j0jO/BjMHwHyKlzySq71rC0uY2W2lzAElLNnfZzBBP3gGVL6xCGUgUKKAwiDAuKym7Mfnf9ClupK2PG47s94d4xZzMsDF1vQqGs5tMNecLSel7ibO7EEl2Wr3IywgCTZcGKCdRv6Q6/6TpH5nNqt0xTlVFbx0bFq97OlTNuly6v9a7F/Q+opQVwwRbhFW87SUGLMuR1u6bkah0tUJlum3G097ws0DpCpGZ3AJ7CTmJF46kz1c3im1UH1eCRjGZyQ2CAJzoDejI7lckBZJteHFldIyTx54n0qhjFRff7YEZynhYvr+kKwODLg2QNWJopFWK28woIpG3Ih1FRn5/Fg1q+DuFuJjYj17Auv92CXxdGCfiqws1o4pkxiPkshojnGEh/8gg3AOPLtZXmEk0NpGNAELxucGMg9/abijLrzke+SRgoyZGxFbHiwzNCrKAZZpmAPrFJRib7IO2AHmJw+my3TXsZ+69LT+hqWWT99BuvifqZAXIS4nhF/Xt4f2wNgBdavs1Q3kRRVHSJjnaHP8emH6I5ddXQ00/05N6cLaxTMn3LipCidIqZOEVNndHxqUq82U/0wrNFPiLO3cVP/Q6Xne5ELyczNbvYXpjNxEYtoaLH4Op6UOeNFUL8HwuNolU3G6FHRDWASt0+jJmZTmut3gkNaQexjs21Z4hRC0gIUMfafbB39aPKY9nznR2E/x5kOs2l8io346D4otWDZLcPydmi7yUW7JzNZ2u0snytyFU1OGdgoAGqx6HScc14fJuw3vpFX9EnWq5oXUMo0olXugyTUdT5ZEBtJxH2hPTn3fi800jJsyQHHsqCfc0RiK8d8Xv6LQ+w6m+iwxuC3rzGgMx53dnh6uuVIWQRDU2nnG9h5VTBYduK3nkOXvLEj6V2n3ZyN2M3Lfc1+ziwA3P0N4DKEpd38xdo1ca6csxscDFGK5T2wOIpynscq/wqj7d9XGO94jAB0DH5vEd+/ZAo0jhISNvd9FMLAuke35mXckS1n055owjPcj/bqQN6n3SPX683k20+E080+7YLRq0WvPqGTLMzIQiJ092CJrXfJi5cWJ6enL2wpUrpP1xwmA77Iuah/I1H818Onw2mD+kdwW9qXT+gUmxtvAupnHML6iFBoovWUgy1WZeQZ6c7B095h2QDFCT96C/wQdPtbvdpR79PO+/8hHLNrqu9Kvcvu5HOtQb3cHNE04ztbNkWL3oAwO59visSobq1yTC9qFsOQ8XiD1tIq1BgMn6j16JVWWU/QIb/6ZwwyABW2o9VHrCgD3BWaHMv7GIu9MNWn17MBHSF7etstxVOCK5mueUSoHX6d37llct9rGXGPtDWgaY5d2DDP5ss4NEhJfDKNg5PTbMTt5tzff3By7enWUu0vDTNZTtmewgq9dKZoM41uxuEWrFPy796C/phrqIeUvoyYWqlPi+V6GjpP1lbpjX1x8FGErVuU3NvV/qhieXg7I6tV+oBTa0+FEf17c4U+8IGrfniapmmbh3lhGV9Rhip3yzRU5tsSeK7QoXxE2/CAH6PMXd//aRgfRXnpo7Axry2/0PEnf0OvkB2nCPiTOM3dXOs5lFklfafEXYr+4ukbtOi+y4vCGb7QJGCncOdjeVX/zfMzfSN67c+3B49Hwui9Km3l4SFbmmRWPGpzkJ3hHhDi8QeL16uHOMzpQxklfR23WsuxoT5O8KQtQCCa8xHG4gHlkHFbDL1aWKdGPB0ihHZw2uCZRqJd+3bqGNVkTFgej40N48BKP+Ms8NF3dRMHve6Ih8c4Z8X64XJS1hD3KmO4hOFTnnCIFrc7S3wcwb8/4YDWbkC9Mb5Be/5ya5gwXVvKjB7aikpihvYvEJ47rtvm+dSWoneC88eMRO7k/NUtHEm6mhHIajpuxkWoLjgnoY2gGivEZ0nrxxndfMwJ093NQe0cukHvdM8GR6VR16CswfDYqO2A9UY7AL9drDw1pjvZjv1NhltfRJ/rmEEPAawE8aZ7dwAdpN94p4yF+oe088Ft4XiHXrIdBTMrKbagZTI/cs0sWBKkTNt86Bkh2jyf+Z1iyWRNt8Lz15kW3cK4cT38GHnSI+AhBsXI4iC832f/4LXSWr1BGB0x5VFw21IU0yv+Hwim37hI2Q16AAAAAElFTkSuQmCC")
-    print("Go to nomics.com for all assets | href=https://nomics.com")
-    for i,value in enumerate(values):
+    print("CoinPaprika")
+    print("Go to coinpaprika.com for all assets | href=https://coinpaprika.com")
+    for value in values:
         print(value)
     print('Refresh | refresh=true')
 
 ## Wrapper method for generating output and printing it
 def std_out(tickers):
-    output_values(generate_bitbar_format(tickers))
+    output_values(generate_xbar_format(tickers))
 
 def main():
-    top_ten = get_top_ten()
-    tickers = get_tickers(",".join(top_ten))
-    std_out(tickers)
+    std_out(get_tickers())
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Three Cryptocurrency plugins have been silently dead since their data providers shut down. I re-verified every host before touching anything:

- `api.nomics.com` no longer resolves (DNS NXDOMAIN), so `nomics_bitbar.py` dies on its first request. The API key hardcoded in the script is moot now.
- `api.coincap.io` no longer resolves either, which kills `Dash/dash-coincap-poloniex.5m.sh`. The same script also calls the legacy `poloniex.com/public` API, which now answers HTTP 410 Gone.
- `coincap.1m.py` never actually used CoinCap despite the name: it pulled from `api.coinmarketcap.com/v1` (removed years ago, requests are blocked with 403) and from keyless CryptoCompare (`min-api.cryptocompare.com` now returns 401 "API key required").

What changed:

- **nomics_bitbar.py**: top ten tickers now come from CoinPaprika's `/v1/tickers` endpoint (free, no key). One request instead of two, and the `requests` dependency is dropped in favor of stdlib `urllib`. The menu output keeps the exact same line shape as before.
- **Dash/dash-coincap-poloniex.5m.sh**: CoinCap data replaced with CoinPaprika, and the Poloniex section moved to the current `api.poloniex.com/markets/DASH_BTC/ticker24h`. Same layout, icon, colors and Dash links. I also reworked the printf calls so plain `shellcheck` passes with zero findings.
- **coincap.1m.py**: both tables (USD and BTC) now come from CoinPaprika tickers plus today's OHLCV, so the open/high/low columns show real numbers again (current UTC day, noted in the plugin desc). Two coin id updates while I was in there: raiblocks is called nano these days (`xno-nano`), and Waltonchain no longer trades anywhere, so I dropped it from the defaults.

I picked CoinPaprika deliberately because it needs no API key. These plugins died silently once already behind hosted providers; a keyless source can't fail that way again, and there is no key to hardcode into the repo. Disclosure: I do DevRel for CoinPaprika, which is how I knew the endpoints. Nothing here requires signing up for anything.

Verification done before opening this PR:

- all three plugins executed locally (via `python3` / `bash` and directly through their shebangs), live output below
- `.test.py -v` passes for all three files: recognized extension, executable bit, valid shebang, required metadata (title, author, author.github) and lint
- plain `shellcheck` (the stricter PR-mode config with no exclusions) and `pyflakes` both come back clean
- every URL in the diff was curl-tested (CoinPaprika coin pages, the Poloniex trade page, dash.org links and both API endpoints)

Original authors stay first in `<xbar.author>`; I added myself as a second author using the comma separated convention from CONTRIBUTING.md, and bumped `<xbar.version>` on each plugin.

<details>
<summary>Live output samples (July 17)</summary>

`nomics_bitbar.py`:

```
CoinPaprika
Go to coinpaprika.com for all assets | href=https://coinpaprika.com
BTC: $62,851.52	-1.79% | color=red
ETH: $1,828.85	-3.35% | color=red
USDT: $0.9992	-0.02% | color=red
...
Refresh | refresh=true
```

`Dash/dash-coincap-poloniex.5m.sh` (icon base64 trimmed):

```
0.000530 | dropdown=false image=<base64>
$33.3519 | dropdown=false image=<base64>
---
:moneybag: BTC: $62832.83 | color=red href="https://coinpaprika.com/coin/btc-bitcoin/"
---
:chart_with_upwards_trend: CoinPaprika.com: | href="https://coinpaprika.com/coin/dash-dash/"
* Rank: 114
* Supply: 12.77M DASH
* Market Cap: $425.84M | color=red
* Price: $33.35 | color=red
* 24h Change: -1.81% | color=red
* 24h Volume: $36.58M
---
:chart_with_upwards_trend: Poloniex.com: | href="https://poloniex.com/trade/DASH_BTC"
* Price: 0.000530 BTC | color=red
* Ask: 0.000532 BTC
* Bid: 0.000528 BTC
* 24h Change: -4.50% | color=red
* 24h Volume: 0.00 BTC
* 24h Volume: 0.00K DASH
* 24h High: 0.000555 BTC | color=green
* 24h Low: 0.000530 BTC | color=red
---
Dash.org | href="https://www.dash.org" image=<base64>
...
```

`coincap.1m.py`:

```
Ƀ
---
COIN     USD     CHANGE   OPEN      HIGH       LOW    RANK|font="Menlo"
BTC   62832.941 -1.880% 63786.664 63971.743 62678.715  001|href='https://coinpaprika.com/coin/btc-bitcoin/' font='Menlo'
ETH   1828.4730 -3.540% 1863.2340 1867.8820 1821.1330  002|href='https://coinpaprika.com/coin/eth-ethereum/' font='Menlo'
LTC   44.909000 +0.460% 44.927000 45.760000 44.818000  032|href='https://coinpaprika.com/coin/ltc-litecoin/' font='Menlo'
IOTA  0.0350000 -2.240% 0.0350000 0.0360000 0.0350000  186|href='https://coinpaprika.com/coin/miota-iota/' font='Menlo'
COIN     BTC     CHANGE   OPEN      HIGH       LOW    RANK|font="Menlo"
NEO   0.0000308 +1.200% 0.0000304 0.0000311 0.0000307  198|href='https://coinpaprika.com/coin/neo-neo/' font='Menlo'
XLM   0.0000029 -0.240% 0.0000029 0.0000030 0.0000029  019|href='https://coinpaprika.com/coin/xlm-stellar/' font='Menlo'
XMR   0.0052462 +0.840% 0.0052411 0.0053548 0.0052241  020|href='https://coinpaprika.com/coin/xmr-monero/' font='Menlo'
XNO   0.0000051 +1.160% 0.0000051 0.0000051 0.0000051  384|href='https://coinpaprika.com/coin/xno-nano/' font='Menlo'
```

</details>

Heads up: `Cryptocurrency/Dash/dash-coincap-binance.5m.sh`, `Cryptocurrency/coin-alert.5s.sh` and `Cryptocurrency/c20.py` also reference dead hosts. I kept this PR to three files so it stays reviewable and I'm happy to follow up on the rest in a separate PR.
